### PR TITLE
Introduce ContentPage based Wayfinder

### DIFF
--- a/packages/website/src/components/Wayfinder.tsx
+++ b/packages/website/src/components/Wayfinder.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 interface WayfinderPage {
   title: string;
   path: string;
+  contentType: string;
   ancestorPages: WayfinderPage[];
   subPages: WayfinderPage[];
 }
@@ -13,13 +14,25 @@ export interface WayfinderProps {
   page: WayfinderPage;
 }
 
+const contentTypeBlacklist = ['KBRootPage', 'FreshersHomepage'];
+
+const inBlacklist = (page: WayfinderPage) =>
+  contentTypeBlacklist.indexOf(page.contentType) > -1;
+const isUsable = (page: WayfinderPage) =>
+  (page !== undefined && !inBlacklist(page) && page) || null;
+
 const getWayfinderDataFromPage = (page: WayfinderPage) => {
   const { ancestorPages } = page;
   const pages = [...ancestorPages, page];
+
+  const section = isUsable(pages[2]);
+  const topic = isUsable(pages[3]);
+  const subnav = isUsable(pages[4]);
+
   return {
-    section: pages[2] || null,
-    topic: pages[3] || null,
-    subnav: pages[4] || null,
+    section: section,
+    topic: (section && topic) || null,
+    subnav: (section && topic && subnav) || null,
   };
 };
 
@@ -44,6 +57,10 @@ const Menu: React.FC<React.HTMLProps<HTMLUListElement>> = ({
 
 export const Wayfinder: React.FC<WayfinderProps> = ({ page }) => {
   const { section, topic, subnav } = getWayfinderDataFromPage(page);
+
+  if (!section) {
+    return null;
+  }
 
   return (
     <div css={{ marginTop: '-1rem', marginBottom: '1rem' }}>

--- a/packages/website/src/components/Wayfinder.tsx
+++ b/packages/website/src/components/Wayfinder.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { COLORS } from '@ussu/common/src/libs/style';
+import { Link } from 'react-router-dom';
+
+interface WayfinderPage {
+  title: string;
+  path: string;
+  ancestorPages: WayfinderPage[];
+  subPages: WayfinderPage[];
+}
+
+export interface WayfinderProps {
+  page: WayfinderPage;
+}
+
+const getWayfinderDataFromPage = (page: WayfinderPage) => {
+  const { ancestorPages } = page;
+  const pages = [...ancestorPages, page];
+  return {
+    section: pages[2] || null,
+    topic: pages[3] || null,
+    subnav: pages[4] || null,
+  };
+};
+
+const Menu: React.FC<React.HTMLProps<HTMLUListElement>> = ({
+  children,
+  ...props
+}) => {
+  return (
+    <ul
+      css={{
+        padding: 0,
+        margin: 0,
+        listStyle: 'none',
+        display: 'inline',
+      }}
+      {...props}
+    >
+      {children}
+    </ul>
+  );
+};
+
+export const Wayfinder: React.FC<WayfinderProps> = ({ page }) => {
+  const { section, topic, subnav } = getWayfinderDataFromPage(page);
+
+  return (
+    <div css={{ marginTop: '-1rem', marginBottom: '1rem' }}>
+      <div
+        css={{
+          background: COLORS.GREY_SUMMER,
+          fontSize: '1.1em',
+        }}
+      >
+        <div className="LokiContainer">
+          <Link
+            css={{
+              display: 'inline',
+              fontWeight: 600,
+              paddingRight: '1rem',
+              color: COLORS.GREY_SAD_SLATE,
+              textDecoration: 'none',
+            }}
+            to={section.path}
+          >
+            {section.title}
+          </Link>
+          <Menu>
+            {section.subPages.map((subPage) => (
+              <li css={{ display: 'inline' }}>
+                <Link
+                  css={[
+                    {
+                      display: 'inline-block',
+                      padding: '0.4rem 0.8rem',
+                      fontWeight: 500,
+                      color: COLORS.GREY_SLATE,
+                      textDecoration: 'none',
+                    },
+                    page.path.startsWith(subPage.path) && [
+                      { color: '#fff', background: COLORS.BRAND_BLUE },
+                    ],
+                  ]}
+                  to={subPage.path}
+                >
+                  {subPage.title}
+                </Link>
+              </li>
+            ))}
+          </Menu>
+        </div>
+      </div>
+      {topic && topic.subPages.length > 0 ? (
+        <div
+          css={{
+            background: COLORS.BRAND_BLUE,
+            color: '#fff',
+            fontWeight: 600,
+            padding: '0.2rem 0',
+          }}
+        >
+          <div className="LokiContainer">
+            <Link
+              css={{
+                display: 'inline',
+                paddingRight: '1rem',
+                color: '#fff',
+                textDecoration: 'none',
+              }}
+              to={topic.path}
+            >
+              {topic.title} ›
+            </Link>
+            <Menu>
+              {topic.subPages.map((subPage) => (
+                <li css={{ display: 'inline' }}>
+                  <Link
+                    css={[
+                      {
+                        padding: '0 0.4rem',
+                        textDecoration: 'none',
+                        color: '#fff',
+                      },
+                      page.path.startsWith(subPage.path) && [
+                        { borderBottom: '2px solid #fff' },
+                      ],
+                    ]}
+                    to={subPage.path}
+                  >
+                    {subPage.title}
+                  </Link>
+                </li>
+              ))}
+            </Menu>
+          </div>
+        </div>
+      ) : null}
+      {subnav && subnav.subPages.length > 0 ? (
+        <div
+          css={{
+            color: COLORS.GREY_SLATE,
+            fontWeight: 500,
+            padding: '0.2rem 0',
+          }}
+        >
+          <div className="LokiContainer">
+            <Link
+              css={{
+                display: 'inline',
+                paddingRight: '1rem',
+                textDecoration: 'none',
+                color: COLORS.GREY_SLATE,
+              }}
+              to={subnav.path}
+            >
+              {subnav.title} ›
+            </Link>
+            <Menu>
+              {subnav.subPages.map((subPage) => (
+                <li css={{ display: 'inline' }}>
+                  <Link
+                    css={{
+                      padding: '0 0.4rem',
+                      textDecoration: 'none',
+                      color: COLORS.GREY_WORST_WINTER,
+                    }}
+                    to={subPage.path}
+                  >
+                    {subPage.title}
+                  </Link>
+                </li>
+              ))}
+            </Menu>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/website/src/containers/WebsiteApplication/index.tsx
+++ b/packages/website/src/containers/WebsiteApplication/index.tsx
@@ -93,6 +93,10 @@ const WebsiteApplication: React.FC<WebsiteApplicationProps> = ({
             from="/freshers/events/"
             to="/whats-on/periods/freshers-week-2019"
           />
+          <Redirect
+            from="/services/outlets/*"
+            to="/about-us/shops-and-bars/*"
+          />
           <Route
             component={FreshersEvents}
             path="/whats-on/periods/freshers-week-2019"
@@ -118,6 +122,7 @@ const WebsiteApplication: React.FC<WebsiteApplicationProps> = ({
             path="/get-involved/campaigns-toolkit"
           />
           <Route component={ContentAPI} path="/about-us/contact" />
+          <Route component={ContentAPI} path="/about-us/shops-and-bars" />
           <Route component={FourOhFourPage} default />
         </Switch>
       </ErrorBoundary>

--- a/packages/website/src/containers/content/ContentPage.tsx
+++ b/packages/website/src/containers/content/ContentPage.tsx
@@ -7,6 +7,7 @@ import { FourOhFourPage } from './FourOhFourPage';
 import { useQuery } from '@apollo/react-hooks';
 import qs from 'query-string';
 import { ErrorState } from '../../components/ErrorState';
+import { Wayfinder } from '../../components/Wayfinder';
 
 interface OwnProps {
   path: string;
@@ -73,6 +74,8 @@ const ContentPage: React.FC<IProps> = (props: IProps) => {
             <meta name="description" content={page.searchDescription} />
           )}
         </Helmet>
+
+        <Wayfinder page={page as any} />
 
         <ContentTypeTemplate page={page} />
       </React.Fragment>

--- a/packages/website/src/containers/content/ContentPageQuery.graphql
+++ b/packages/website/src/containers/content/ContentPageQuery.graphql
@@ -208,6 +208,27 @@ fragment ContentPageGenerals on Page {
 
   contentType
   lastPublishedAt
+  subPages {
+    title
+    slug
+    path
+
+    seoTitle
+    searchDescription
+
+    contentType
+  }
+
+  ancestorPages {
+    title
+    slug
+    path
+    subPages {
+      title
+      slug
+      path
+    }
+  }
 }
 
 fragment FalmerImage on Image {

--- a/packages/website/src/containers/content/ContentPageQuery.graphql
+++ b/packages/website/src/containers/content/ContentPageQuery.graphql
@@ -223,7 +223,9 @@ fragment ContentPageGenerals on Page {
     title
     slug
     path
+    contentType
     subPages {
+      contentType
       title
       slug
       path

--- a/packages/website/src/containers/content/pages/OfficerEventsPage.tsx
+++ b/packages/website/src/containers/content/pages/OfficerEventsPage.tsx
@@ -6,7 +6,6 @@ import { EventListings } from '../../EventsCalender/EventListings';
 import { useQuery } from '@apollo/react-hooks';
 import { startOfDay, addMonths } from 'date-fns/esm';
 import Loader from '../../../components/Loader';
-import { Sectionbar } from '../../../components/Sectionbar';
 
 interface IOfficerEventsIndex extends Page<Page[]> {}
 
@@ -43,7 +42,6 @@ export const OfficerEventsPage: React.FC<OfficerEventsPageProps> = ({
 
   return (
     <div>
-      <Sectionbar title={page.section.title} titleLink={page.section.path} />
       <div className="LokiContainer">
         <h1>{page.title}</h1>
         {convert(page.description)}

--- a/packages/website/src/containers/content/pages/OfficerOverviewPage.tsx
+++ b/packages/website/src/containers/content/pages/OfficerOverviewPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Page, StreamFieldData } from '../types';
-import { Sectionbar, SectionbarItem } from '../../../components/Sectionbar';
 import { Link } from 'react-router-dom';
 import { AspectRatio, OneImage } from '@ussu/website/src/components/OneImage';
 import { FalmerImage } from '@ussu/common/src/types/events';
@@ -84,13 +83,6 @@ export const OfficerOverviewPage: React.FC<OfficerOverviewPageProps> = ({
   return (
     <div>
       <Helmet title={`${page.role} | ${page.firstName} ${page.lastName}`} />
-      <Sectionbar title={page.section.title} titleLink={page.section.path}>
-        {page.section.subPages.map((page) => (
-          <SectionbarItem key={page.path}>
-            <Link to={page.path}>{page.title}</Link>
-          </SectionbarItem>
-        ))}
-      </Sectionbar>
 
       <div className="LokiContainer">
         <div className="Layout Layout--sidebar-left" css={topOverviewStyles}>

--- a/packages/website/src/containers/content/pages/OfficersIndex.tsx
+++ b/packages/website/src/containers/content/pages/OfficersIndex.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Page } from '../types';
 import { FalmerImage } from '@ussu/common/src/types/events';
 import { Link } from 'react-router-dom';
-import { Sectionbar, SectionbarItem } from '../../../components/Sectionbar';
 import { OneImage, AspectRatio } from '../../../components/OneImage';
 import convert from 'htmr';
 import { SocialArray } from '../../../components/SocialArray';
@@ -66,13 +65,6 @@ const socialLinks = (pageObj: OfficerPagePreview): NetworkItem => {
 
 export const OfficersIndex: React.FC<OfficerIndexProps> = ({ page }) => (
   <React.Fragment>
-    <Sectionbar title={page.section.title} titleLink={page.section.path}>
-      {page.section.subPages.map((page) => (
-        <SectionbarItem key={page.path}>
-          <Link to={page.path}>{page.title}</Link>
-        </SectionbarItem>
-      ))}
-    </Sectionbar>
     <div className="LokiContainer">
       {page.subPages.map((page) => (
         <div className="Trail Trail__row--12">

--- a/packages/website/src/containers/content/pages/OutletIndexPage.tsx
+++ b/packages/website/src/containers/content/pages/OutletIndexPage.tsx
@@ -3,7 +3,6 @@ import { Page, StreamFieldData } from '../types';
 import StreamField from '../../content/StreamField';
 import { FalmerImage } from '@ussu/common/src/types/events';
 import { Link } from 'react-router-dom';
-import { Sectionbar, SectionbarItem } from '../../../components/Sectionbar';
 import { OneImageBackground } from '../../../components/OneImage';
 import { Typeface, TypeSize, type } from '@ussu/common/src/libs/style/type';
 import { css } from '@emotion/core';
@@ -64,13 +63,6 @@ const titleStyles = css({
 
 export const OutletIndexPage: React.FC<OutletIndexPageProps> = ({ page }) => (
   <React.Fragment>
-    <Sectionbar title={page.section.title} titleLink={page.section.path}>
-      {page.section.subPages.map((page) => (
-        <SectionbarItem key={page.path}>
-          <Link to={page.path}>{page.title}</Link>
-        </SectionbarItem>
-      ))}
-    </Sectionbar>
     <div className="LokiContainer">
       <div className="type-body-copy">
         <StreamField page={page} items={page.preamble} />

--- a/packages/website/src/containers/content/pages/OutletPage.tsx
+++ b/packages/website/src/containers/content/pages/OutletPage.tsx
@@ -5,8 +5,6 @@ import StreamField from '../../content/StreamField';
 import { ContentCard } from '../../../components/ContentCard';
 import { OneImageBackground } from '../../../components/OneImage';
 import { openingTimesBlockParser } from '@ussu/common/src/libs/streamFieldStructures';
-import { Sectionbar, SectionbarItem } from '../../../components/Sectionbar';
-import { Link } from 'react-router-dom';
 import {
   isOpenNow,
   OpeningTimeInterval,
@@ -119,13 +117,6 @@ export const OutletPage: React.FC<OutletPageProps> = ({ page }) => {
 
   return (
     <div>
-      <Sectionbar title={page.section.title} titleLink={page.section.path}>
-        {page.section.subPages.map((page) => (
-          <SectionbarItem key={page.path}>
-            <Link to={page.path}>{page.title}</Link>
-          </SectionbarItem>
-        ))}
-      </Sectionbar>
       <OneImageBackground
         className={'Layout--content-top-bleed'}
         css={headerStyles}

--- a/packages/website/src/routes.ts
+++ b/packages/website/src/routes.ts
@@ -18,6 +18,7 @@ export default new PreRouter([
   /^\/get-involved\/decision-making/,
   /^\/about-us\/contact/,
   /^\/about-us$/,
+  /^\/about-us\/shops-and-bars/,
   /^\/support$/,
   '/get-involved-next',
   '/get-involved/campaigns-toolkit',


### PR DESCRIPTION
- [x] Allow templates to disable levels of the navigation (this should work from a descendant perspective. e.g: Knowledge base root is flagged as non-menu, is level 2 in the ancestors, so the topic and subnav is removed)
- [ ] Decide on menu overflow strategy
- [ ] Ensure it is clear when menus have a single child, and you're on the parent. 
