### PR TITLE
Add basic event tags, replacing banners

### DIFF
--- a/packages/website/src/containers/EventsCalender/EventListingFragment.graphql
+++ b/packages/website/src/containers/EventsCalender/EventListingFragment.graphql
@@ -12,6 +12,16 @@ fragment EventListingFragment on Event {
   cost
   ticketLevel
   ticketType
+
+  audienceSuitableKidsFamilies
+  isOver18Only
+
+  type {
+    name
+  }
+  categories {
+    name
+  }
   userLike {
     source
   }


### PR DESCRIPTION
These are created by a generator given an event object.

Tags currently have three types:
- Requirement: things you must know (18+)
- Info: additional information (Low availability)
- Taste: event categorisation (Music, Grime, Film Screening)

They are displayed in that order. Tags are given a single line, any extra is clipped by overflow: hidden.

<img width="342" alt="Screenshot 2019-09-19 at 14 47 00" src="https://user-images.githubusercontent.com/382352/65249737-68638380-daec-11e9-9dcc-60a03ce3302b.png">
