### PR TITLE
Reduce any/eslint warnings

### DIFF
--- a/packages/basil/src/Accordion/Accordion.stories.tsx
+++ b/packages/basil/src/Accordion/Accordion.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Accordion } from './index';
 
 export default { title: 'Navigation|Accordion' };

--- a/packages/basil/src/Accordion/Accordion.stories.tsx
+++ b/packages/basil/src/Accordion/Accordion.stories.tsx
@@ -3,5 +3,5 @@ import React from 'react';
 import { Accordion } from './index';
 
 export default { title: 'Navigation|Accordion' };
-export const Closed = () => <Accordion isOpen={false} />;
-export const Open = () => <Accordion isOpen={true} />;
+export const Closed: React.FC = () => <Accordion isOpen={false} />;
+export const Open: React.FC = () => <Accordion isOpen={true} />;

--- a/packages/basil/src/Accordion/index.tsx
+++ b/packages/basil/src/Accordion/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-interface IProps {
+interface AccordionProps {
   isOpen: boolean;
 }
 
-export const Accordion: React.FC<IProps> = ({ isOpen }) => {
+export const Accordion: React.FC<AccordionProps> = ({ isOpen }) => {
   return (
     <ul className="ModalAccordion">
       <li className="ModalAccordion__item">

--- a/packages/basil/src/BackBar/BackBar.stories.tsx
+++ b/packages/basil/src/BackBar/BackBar.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { BackBar } from '../../../website/src/components/BackBar/index';
 
 export default { title: 'Navigation|BackBar' };

--- a/packages/basil/src/BrandColors/BrandColors.stories.tsx
+++ b/packages/basil/src/BrandColors/BrandColors.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { BrandColorCard } from './index';
 import { COLORS } from '../style';
 

--- a/packages/basil/src/BrandColors/BrandColors.stories.tsx
+++ b/packages/basil/src/BrandColors/BrandColors.stories.tsx
@@ -5,10 +5,10 @@ import { COLORS } from '../style';
 
 export default { title: 'System|Brand Color' };
 
-export const AllColors = () => (
+export const AllColors: React.FC = () => (
   <div>
     {Object.entries(COLORS).map(([name, color]) => (
-      <BrandColorCard color={color} name={name} />
+      <BrandColorCard key={color} color={color} name={name} />
     ))}
   </div>
 );

--- a/packages/basil/src/BreadcrumbBar/BreadcrumbBar.stories.tsx
+++ b/packages/basil/src/BreadcrumbBar/BreadcrumbBar.stories.tsx
@@ -19,4 +19,4 @@ const crumbs = [
 
 export default { title: 'Navigation|BreadcrumbBar' };
 
-export const normal = () => <BreadcrumbBar>{crumbs}</BreadcrumbBar>;
+export const normal: React.FC = () => <BreadcrumbBar>{crumbs}</BreadcrumbBar>;

--- a/packages/basil/src/BreadcrumbBar/BreadcrumbBar.stories.tsx
+++ b/packages/basil/src/BreadcrumbBar/BreadcrumbBar.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { BreadcrumbBar } from '../../../website/src/components/BreadcrumbBar/index';
 
 const crumbs = [

--- a/packages/basil/src/BrickWall/BrickWall.stories.tsx
+++ b/packages/basil/src/BrickWall/BrickWall.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default { title: 'Navigation|Brick Wall' };
 
-export const Default = () => (
+export const Default: React.FC = () => (
   <ul className="BrickWall List--reset">
     <li className="BrickWall__item">
       <button className="BrickWall__anchor" type="button">

--- a/packages/basil/src/BrickWall/BrickWall.stories.tsx
+++ b/packages/basil/src/BrickWall/BrickWall.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default { title: 'Navigation|Brick Wall' };
 
 export const Default = () => (

--- a/packages/basil/src/Button/Button.stories.tsx
+++ b/packages/basil/src/Button/Button.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Button } from './index';
 
 export default { title: 'Form|Button' };

--- a/packages/basil/src/Button/Button.stories.tsx
+++ b/packages/basil/src/Button/Button.stories.tsx
@@ -4,31 +4,31 @@ import { Button } from './index';
 
 export default { title: 'Form|Button' };
 
-export const Default = () => (
+export const Default: React.FC = () => (
   <Button className="Button" href="#">
     Default button
   </Button>
 );
 
-export const EndOfCard = () => (
+export const EndOfCard: React.FC = () => (
   <Button className="Button Button--endOfCard" href="#">
     Default button
   </Button>
 );
 
-export const Start = () => (
+export const Start: React.FC = () => (
   <Button className="Button Button--start" href="#">
     Start button
   </Button>
 );
 
-export const Danger = () => (
+export const Danger: React.FC = () => (
   <Button className="Button Button--color-red" href="#">
     Red button
   </Button>
 );
 
-export const Confirm = () => (
+export const Confirm: React.FC = () => (
   <Button className="Button Button--color-green" href="#">
     Green button
   </Button>

--- a/packages/basil/src/Button/index.tsx
+++ b/packages/basil/src/Button/index.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { css } from '@emotion/core';
 
-interface IProps {
+interface ButtonProps {
   href: string;
-  children: any;
   className?: string;
 }
 
-export const Button: React.FC<IProps> = ({ href, children, className }) => {
+export const Button: React.FC<ButtonProps> = ({
+  href,
+  children,
+  className,
+}) => {
   return (
     <a href={href} className={className} css={css({ display: 'block' })}>
       {children}

--- a/packages/basil/src/ContentCard/ContentCard.stories.tsx
+++ b/packages/basil/src/ContentCard/ContentCard.stories.tsx
@@ -4,14 +4,14 @@ import { ContentCard } from './index';
 
 export default { title: 'ContentCard' };
 
-export const Standard = () => (
+export const Standard: React.FC = () => (
   <ContentCard>
     <h1>Hello there</h1>
     <h2>This is a content card with content inside.</h2>
   </ContentCard>
 );
 
-export const Error = () => (
+export const Error: React.FC = () => (
   <ContentCard className="ContentCard__error-message">
     <span>This is an error message in a content card</span>
   </ContentCard>

--- a/packages/basil/src/ContentCard/ContentCard.stories.tsx
+++ b/packages/basil/src/ContentCard/ContentCard.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { ContentCard } from './index';
 
 export default { title: 'ContentCard' };

--- a/packages/basil/src/ContentCard/index.tsx
+++ b/packages/basil/src/ContentCard/index.tsx
@@ -13,7 +13,6 @@ export const ContentCardContent: React.FC = ({ children }) => (
 export const ContentCard: React.FC<ContentCardProps> = ({
   anchor = undefined,
   children,
-  bleed = false,
   className,
   ...props
 }) => (

--- a/packages/basil/src/ContentNavigation/ContentNavigation.stories.tsx
+++ b/packages/basil/src/ContentNavigation/ContentNavigation.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ContentNavigation } from '../../../website/src/components/ContentNavigation/index';
 import slugify from '@ussu/common/src/libs/slugify';
 

--- a/packages/basil/src/CookieMessage/CookieMessage.stories.tsx
+++ b/packages/basil/src/CookieMessage/CookieMessage.stories.tsx
@@ -3,4 +3,4 @@ import { CookieMessage } from '../../../website/src/components/CookieMessage/ind
 
 export default { title: 'Page|CookieMessage' };
 
-export const Default = () => <CookieMessage />;
+export const Default: React.FC = () => <CookieMessage />;

--- a/packages/basil/src/CookieMessage/CookieMessage.stories.tsx
+++ b/packages/basil/src/CookieMessage/CookieMessage.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { CookieMessage } from '../../../website/src/components/CookieMessage/index';
 
 export default { title: 'Page|CookieMessage' };

--- a/packages/basil/src/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/packages/basil/src/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { CopyToClipboardButton } from '../../../website/src/components/CopyToClipboardButton/index';
 
 export default { title: 'Utils|Copy to clipboard' };

--- a/packages/basil/src/DeckChair/Deckchair.stories.tsx
+++ b/packages/basil/src/DeckChair/Deckchair.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import React from 'react';
 import { Deckchair } from '../../../website/src/components/Deckchair/index';
 
 export default { title: 'Deckchair' };

--- a/packages/basil/src/ErrorState/ErrorState.stories.tsx
+++ b/packages/basil/src/ErrorState/ErrorState.stories.tsx
@@ -1,7 +1,8 @@
+import React from 'react';
 import { ErrorState } from '../../../website/src/components/ErrorState/index';
 
 export default { title: 'Utils|ErrorState' };
-export const Standard = () => (
+export const Standard: React.FC = () => (
   <div>
     <ErrorState />
   </div>

--- a/packages/basil/src/Footer/Footer.stories.tsx
+++ b/packages/basil/src/Footer/Footer.stories.tsx
@@ -1,5 +1,6 @@
+import React from 'react';
 import { Footer } from '../../../website/src/components/Footer/index';
 
 export default { title: 'Page|Footer' };
 
-export const Standard = () => <Footer />;
+export const Standard: React.FC = () => <Footer />;

--- a/packages/basil/src/Heading/Heading.stories.tsx
+++ b/packages/basil/src/Heading/Heading.stories.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
 import { Heading, HeadingLevel } from '../../../website/src/components/Heading';
 
 export default { title: 'Typography|Headings' };
 
-export const Default = () => (
+export const Default: React.FC = () => (
   <div>
     <Heading level={HeadingLevel.h1}>This is a level 1 heading </Heading>
     <hr></hr>

--- a/packages/basil/src/HomepageSplash/HomepageSplash.stories.tsx
+++ b/packages/basil/src/HomepageSplash/HomepageSplash.stories.tsx
@@ -1,5 +1,6 @@
+import React from 'react';
 import { HomepageSplash } from '../../../website/src/components/HomepageSplash/index';
 
 export default { title: 'Homepage Splash' };
 
-export const Standard = () => <HomepageSplash />;
+export const Standard: React.FC = () => <HomepageSplash />;

--- a/packages/basil/src/HoverTapTooltip.stories.tsx/HoverTapTooltip.stories.tsx
+++ b/packages/basil/src/HoverTapTooltip.stories.tsx/HoverTapTooltip.stories.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
 import { HoverTapTooltip } from '../../../website/src/components/HoverTapToolTip/index';
 
 export default { title: 'Utils|HoverTapTooltip' };
 
-export const Default = () => (
+export const Default: React.FC = () => (
   <div>
     <h1>Tooltip demo</h1>
 

--- a/packages/basil/src/Icons/Icons.stories.tsx
+++ b/packages/basil/src/Icons/Icons.stories.tsx
@@ -6,6 +6,6 @@ import { SearchIcon } from '../../../website/src/components/SearchIcon';
 
 export default { title: 'Utils|Icons' };
 
-export const Search = () => <SearchIcon />;
-export const Menu = () => <MenuIcon />;
-export const Cross = () => <CrossIcon />;
+export const Search: React.FC = () => <SearchIcon />;
+export const Menu: React.FC = () => <MenuIcon />;
+export const Cross: React.FC = () => <CrossIcon />;

--- a/packages/basil/src/Icons/Icons.stories.tsx
+++ b/packages/basil/src/Icons/Icons.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { CrossIcon } from '../../../website/src/components/CrossIcon';
 import { MenuIcon } from '../../../website/src/components/MenuIcon';
 import { SearchIcon } from '../../../website/src/components/SearchIcon';

--- a/packages/basil/src/InternalAppLink/InternalAppLink.stories.tsx
+++ b/packages/basil/src/InternalAppLink/InternalAppLink.stories.tsx
@@ -3,6 +3,6 @@ import { InternalAppLink } from '../../../website/src/components/InternalAppLink
 
 export default { title: 'Utils|Internal App Link' };
 
-export const Standard = () => (
+export const Standard: React.FC = () => (
   <InternalAppLink to="#">Test internal app link</InternalAppLink>
 );

--- a/packages/basil/src/InternalAppLink/InternalAppLink.stories.tsx
+++ b/packages/basil/src/InternalAppLink/InternalAppLink.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { InternalAppLink } from '../../../website/src/components/InternalAppLink/index';
 
 export default { title: 'Utils|Internal App Link' };

--- a/packages/basil/src/LoadableLoading/LoadableLoading.stories.tsx
+++ b/packages/basil/src/LoadableLoading/LoadableLoading.stories.tsx
@@ -3,7 +3,7 @@ import { LoadableLoading } from '../../../website/src/components/LoadableLoading
 
 export default { title: 'Utils|Module Loader' };
 
-export const ErrorState = () => (
+export const ErrorState: React.FC = () => (
   <LoadableLoading
     error={new Error('failure')}
     timedOut={false}
@@ -11,10 +11,10 @@ export const ErrorState = () => (
   />
 );
 
-export const TimeOutState = () => (
+export const TimeOutState: React.FC = () => (
   <LoadableLoading error={null} timedOut={true} pastDelay={false} />
 );
 
-export const PastDelayState = () => (
+export const PastDelayState: React.FC = () => (
   <LoadableLoading error={null} timedOut={false} pastDelay={true} />
 );

--- a/packages/basil/src/LoadableLoading/LoadableLoading.stories.tsx
+++ b/packages/basil/src/LoadableLoading/LoadableLoading.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { LoadableLoading } from '../../../website/src/components/LoadableLoading/index';
 
 export default { title: 'Utils|Module Loader' };

--- a/packages/basil/src/Loader/Loader.stories.tsx
+++ b/packages/basil/src/Loader/Loader.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Loader } from '../../../website/src/components/Loader';
 
 export default { title: 'Utils|Loader' };

--- a/packages/basil/src/Loader/Loader.stories.tsx
+++ b/packages/basil/src/Loader/Loader.stories.tsx
@@ -3,5 +3,5 @@ import { Loader } from '../../../website/src/components/Loader';
 
 export default { title: 'Utils|Loader' };
 
-export const Light = () => <Loader />;
-export const Dark = () => <Loader dark />;
+export const Light: React.FC = () => <Loader />;
+export const Dark: React.FC = () => <Loader dark />;

--- a/packages/basil/src/LokiHeader/LokiHeader.stories.tsx
+++ b/packages/basil/src/LokiHeader/LokiHeader.stories.tsx
@@ -2,4 +2,4 @@ import React from 'react';
 import { LokiHeader } from '../../../website/src/components/LokiHeader/index';
 
 export default { title: 'Page|LokiHeader' };
-export const Standard = () => <LokiHeader />;
+export const Standard: React.FC = () => <LokiHeader />;

--- a/packages/basil/src/LokiHeader/LokiHeader.stories.tsx
+++ b/packages/basil/src/LokiHeader/LokiHeader.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { LokiHeader } from '../../../website/src/components/LokiHeader/index';
 
 export default { title: 'Page|LokiHeader' };

--- a/packages/basil/src/LokiMenu/LokiMenu.stories.tsx
+++ b/packages/basil/src/LokiMenu/LokiMenu.stories.tsx
@@ -3,4 +3,4 @@ import { LokiMenu } from '../../../website/src/components/LokiMenu/index';
 
 export default { title: 'Page|LokiMenu' };
 
-export const Standard = () => <LokiMenu />;
+export const Standard: React.FC = () => <LokiMenu />;

--- a/packages/basil/src/LokiMenu/LokiMenu.stories.tsx
+++ b/packages/basil/src/LokiMenu/LokiMenu.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { LokiMenu } from '../../../website/src/components/LokiMenu/index';
 
 export default { title: 'Page|LokiMenu' };

--- a/packages/basil/src/LokiSideMenu/LokiSideMenu.stories.tsx
+++ b/packages/basil/src/LokiSideMenu/LokiSideMenu.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { LokiSideMenu } from '../../../website/src/components/LokiSideMenu/index';
 
 export default { title: 'Page|LokiSideMenu' };

--- a/packages/basil/src/LokiSideMenu/LokiSideMenu.stories.tsx
+++ b/packages/basil/src/LokiSideMenu/LokiSideMenu.stories.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 import { LokiSideMenu } from '../../../website/src/components/LokiSideMenu/index';
 
 export default { title: 'Page|LokiSideMenu' };
-export const Closed = () => (
+export const Closed: React.FC = () => (
   <LokiSideMenu isOpen={true} onBackdropClick={() => function() {}} />
 );

--- a/packages/basil/src/MobileFooterTreats/MobileFooterTreats.stories.tsx
+++ b/packages/basil/src/MobileFooterTreats/MobileFooterTreats.stories.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 
 export default { title: 'Page|Mobile Footer Treats' };
 
-export const Default = () => (
+export const Default: React.FC = () => (
   <div className="MobileFooterTreats" css={css({ display: 'block' })}>
     <div className="MobileFooterTreats__social">
       <SocialMenu mobile />

--- a/packages/basil/src/MobileFooterTreats/MobileFooterTreats.stories.tsx
+++ b/packages/basil/src/MobileFooterTreats/MobileFooterTreats.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { SocialMenu } from '../../../website/src/components/SocialMenu';
 import { css } from '@emotion/core';
 

--- a/packages/basil/src/Modal/Modal.stories.tsx
+++ b/packages/basil/src/Modal/Modal.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Modal } from '../../../website/src/components/Modal';
 
 export default { title: 'Modal' };

--- a/packages/basil/src/NewsList/NewsBlock.stories.tsx
+++ b/packages/basil/src/NewsList/NewsBlock.stories.tsx
@@ -3,7 +3,7 @@ import { NewsBlock } from '../../../website/src/components/NewsList/NewsBlock';
 
 export default { title: 'NewsBlock' };
 
-export const Standard = () => (
+export const Standard: React.FC = () => (
   <NewsBlock
     item={{
       id: 2,

--- a/packages/basil/src/NewsList/NewsBlock.stories.tsx
+++ b/packages/basil/src/NewsList/NewsBlock.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { NewsBlock } from '../../../website/src/components/NewsList/NewsBlock';
 
 export default { title: 'NewsBlock' };

--- a/packages/basil/src/NewsletterSignup/NewsletterSignup.stories.tsx
+++ b/packages/basil/src/NewsletterSignup/NewsletterSignup.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { NewsletterSignup } from '../../../website/src/components/NewsletterSignup/index';
 
 export default { title: 'NewsletterSignup' };

--- a/packages/basil/src/NewsletterSignup/NewsletterSignup.stories.tsx
+++ b/packages/basil/src/NewsletterSignup/NewsletterSignup.stories.tsx
@@ -3,4 +3,4 @@ import { NewsletterSignup } from '../../../website/src/components/NewsletterSign
 
 export default { title: 'NewsletterSignup' };
 
-export const Default = () => <NewsletterSignup />;
+export const Default: React.FC = () => <NewsletterSignup />;

--- a/packages/basil/src/OneImage/OneImage.stories.tsx
+++ b/packages/basil/src/OneImage/OneImage.stories.tsx
@@ -7,7 +7,7 @@ import {
 
 export default { title: 'Utils|OneImage' };
 
-export const r16by9 = () => (
+export const r16by9: React.FC = () => (
   <OneImage
     aspectRatio={AspectRatio.r16by9}
     src="asset/News/6412/unnamed.jpg"
@@ -16,7 +16,7 @@ export const r16by9 = () => (
   />
 );
 
-export const r1by1 = () => (
+export const r1by1: React.FC = () => (
   <OneImage
     aspectRatio={AspectRatio.r1by1}
     src="asset/News/6412/unnamed.jpg"
@@ -25,7 +25,7 @@ export const r1by1 = () => (
   />
 );
 
-export const r20by9 = () => (
+export const r20by9: React.FC = () => (
   <OneImage
     aspectRatio={AspectRatio.r20by9}
     src="asset/News/6412/unnamed.jpg"
@@ -33,7 +33,7 @@ export const r20by9 = () => (
     mslResource
   />
 );
-export const r3by4 = () => (
+export const r3by4: React.FC = () => (
   <OneImage
     aspectRatio={AspectRatio.r3by4}
     src="asset/News/6412/unnamed.jpg"

--- a/packages/basil/src/OneImage/OneImage.stories.tsx
+++ b/packages/basil/src/OneImage/OneImage.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   AspectRatio,
   OneImage,

--- a/packages/basil/src/OrganisationCard/OrganisationCard.stories.tsx
+++ b/packages/basil/src/OrganisationCard/OrganisationCard.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { PatternPlaceholder } from '../../../website/src/components/PatternPlaceholder';
 
 export default { title: 'Organisation Card' };

--- a/packages/basil/src/OrganisationCard/OrganisationCard.stories.tsx
+++ b/packages/basil/src/OrganisationCard/OrganisationCard.stories.tsx
@@ -3,7 +3,7 @@ import { PatternPlaceholder } from '../../../website/src/components/PatternPlace
 
 export default { title: 'Organisation Card' };
 
-export const Default = () => (
+export const Default: React.FC = () => (
   <li className="TrailGrid__item">
     <a className="OrganisationCard__link" href="#">
       <div className="OrganisationCard__image-container">
@@ -17,7 +17,7 @@ export const Default = () => (
   </li>
 );
 
-export const InProgress = () => (
+export const InProgress: React.FC = () => (
   <li className="TrailGrid__item">
     <a className="OrganisationCard__link" href="#">
       <div className="OrganisationCard__image-container">

--- a/packages/basil/src/PaginationNavigation/PaginationNavigation.stories.tsx
+++ b/packages/basil/src/PaginationNavigation/PaginationNavigation.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { PaginationNavigation } from '../../../website/src/components/PaginationNavigation/index';
 
 export default { title: 'Navigation|Pagination Navigation' };

--- a/packages/basil/src/PaginationNavigation/PaginationNavigation.stories.tsx
+++ b/packages/basil/src/PaginationNavigation/PaginationNavigation.stories.tsx
@@ -3,7 +3,7 @@ import { PaginationNavigation } from '../../../website/src/components/Pagination
 
 export default { title: 'Navigation|Pagination Navigation' };
 
-export const First = () => (
+export const First: React.FC = () => (
   <PaginationNavigation
     currentPage={1}
     onPageChange={() => ({})}
@@ -11,7 +11,7 @@ export const First = () => (
   />
 );
 
-export const Middle = () => (
+export const Middle: React.FC = () => (
   <PaginationNavigation
     currentPage={3}
     onPageChange={() => ({})}
@@ -19,7 +19,7 @@ export const Middle = () => (
   />
 );
 
-export const Last = () => (
+export const Last: React.FC = () => (
   <PaginationNavigation
     currentPage={6}
     onPageChange={() => ({})}

--- a/packages/basil/src/PatternPlaceholder/PatternPlaceholder.stories.tsx
+++ b/packages/basil/src/PatternPlaceholder/PatternPlaceholder.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import React from 'react';
 import { PatternPlaceholder } from '../../../website/src/components/PatternPlaceholder';
 
 export default { title: 'Utils|Pattern Placeholder' };
 
-export const Standard = () => <PatternPlaceholder />;
+export const Standard: React.FC = () => <PatternPlaceholder />;

--- a/packages/basil/src/PatternPlaceholder/PatternPlaceholder.stories.tsx
+++ b/packages/basil/src/PatternPlaceholder/PatternPlaceholder.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import React from 'react';
 import { PatternPlaceholder } from '../../../website/src/components/PatternPlaceholder';
 
 export default { title: 'Utils|Pattern Placeholder' };

--- a/packages/basil/src/PersonCollection/PersonCollection.stories.tsx
+++ b/packages/basil/src/PersonCollection/PersonCollection.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { PersonCollectionFigure } from '../../../website/src/components/PersonCollection/PersonCollectionFigure';
 
 export default { title: 'Person Collection' };

--- a/packages/basil/src/PrefooterMenu/PrefooterMenu.stories.tsx
+++ b/packages/basil/src/PrefooterMenu/PrefooterMenu.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { PrefooterMenu } from '../../../website/src/components/PrefooterMenu';
 
 export default { title: 'Page|Prefooter Menu' };

--- a/packages/basil/src/PrefooterMenu/PrefooterMenu.stories.tsx
+++ b/packages/basil/src/PrefooterMenu/PrefooterMenu.stories.tsx
@@ -3,4 +3,4 @@ import { PrefooterMenu } from '../../../website/src/components/PrefooterMenu';
 
 export default { title: 'Page|Prefooter Menu' };
 
-export const Standard = () => <PrefooterMenu />;
+export const Standard: React.FC = () => <PrefooterMenu />;

--- a/packages/basil/src/ProfileLabel/ProfileLabel.stories.tsx
+++ b/packages/basil/src/ProfileLabel/ProfileLabel.stories.tsx
@@ -3,4 +3,4 @@ import { ProfileLabel } from '../../../website/src/components/LokiHeader/Profile
 
 export default { title: 'Page|Profile Label' };
 
-export const Standard = () => <ProfileLabel />;
+export const Standard: React.FC = () => <ProfileLabel />;

--- a/packages/basil/src/ProfileLabel/ProfileLabel.stories.tsx
+++ b/packages/basil/src/ProfileLabel/ProfileLabel.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ProfileLabel } from '../../../website/src/components/LokiHeader/ProfileLabel';
 
 export default { title: 'Page|Profile Label' };

--- a/packages/basil/src/Sectionbar/Sectionbar.stories.tsx
+++ b/packages/basil/src/Sectionbar/Sectionbar.stories.tsx
@@ -6,8 +6,8 @@ import {
 
 export default { title: 'Navigation|Sectionbar' };
 
-export const Empty = () => <Sectionbar title="Sectionbar" />;
-export const WithNavItems = () => (
+export const Empty: React.FC = () => <Sectionbar title="Sectionbar" />;
+export const WithNavItems: React.FC = () => (
   <Sectionbar title="Sectionbar">
     <SectionbarItem>
       <a href="#">Home</a>

--- a/packages/basil/src/SocialArray/SocialArray.stories.tsx
+++ b/packages/basil/src/SocialArray/SocialArray.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { SocialArray } from '../../../website/src/components/SocialArray/index';
 
 export default { title: 'SocialArray' };

--- a/packages/basil/src/SocialArray/SocialArray.stories.tsx
+++ b/packages/basil/src/SocialArray/SocialArray.stories.tsx
@@ -3,7 +3,7 @@ import { SocialArray } from '../../../website/src/components/SocialArray/index';
 
 export default { title: 'SocialArray' };
 
-export const Standard = () => (
+export const Standard: React.FC = () => (
   <SocialArray
     networks={{
       twitter: {

--- a/packages/basil/src/SocialMenu/SocialMenu.stories.tsx
+++ b/packages/basil/src/SocialMenu/SocialMenu.stories.tsx
@@ -3,6 +3,6 @@ import { SocialMenu } from '../../../website/src/components/SocialMenu/index';
 
 export default { title: 'SocialMenu' };
 
-export const Standard = () => <SocialMenu />;
-export const Mobile = () => <SocialMenu mobile />;
-export const List = () => <SocialMenu asList mobile />;
+export const Standard: React.FC = () => <SocialMenu />;
+export const Mobile: React.FC = () => <SocialMenu mobile />;
+export const List: React.FC = () => <SocialMenu asList mobile />;

--- a/packages/basil/src/SocialMenu/SocialMenu.stories.tsx
+++ b/packages/basil/src/SocialMenu/SocialMenu.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { SocialMenu } from '../../../website/src/components/SocialMenu/index';
 
 export default { title: 'SocialMenu' };

--- a/packages/basil/src/Tags/Tags.stories.tsx
+++ b/packages/basil/src/Tags/Tags.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tag, Tags } from '../../../website/src/components/Tags/index';
 
 export default { title: 'Tags' };
-export const Standard = () => (
+export const Standard: React.FC = () => (
   <Tags>
     <Tag>
       <a href="#">Awesome</a>

--- a/packages/basil/src/Tags/Tags.stories.tsx
+++ b/packages/basil/src/Tags/Tags.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Tag, Tags } from '../../../website/src/components/Tags/index';
 
 export default { title: 'Tags' };

--- a/packages/basil/src/Type/Type.stories.tsx
+++ b/packages/basil/src/Type/Type.stories.tsx
@@ -40,12 +40,13 @@ const types = [
 ];
 
 export default { title: 'Typography|Scale' };
-export const Standard = () => (
+export const Standard: React.FC = () => (
   <div className="LokiContainer">
     <h1>Primary typeface: Larsseit Bold</h1>
     <div className="type-primary" style={{ fontWeight: 600 }}>
       {types.map((t) => (
         <div
+          key={t.name}
           style={{
             display: 'flex',
             borderBottom: '1px solid grey',
@@ -68,6 +69,7 @@ export const Standard = () => (
     <div>
       {types.map((t) => (
         <div
+          key={t.name}
           style={{
             display: 'flex',
             borderBottom: '1px solid grey',

--- a/packages/basil/src/Type/Type.stories.tsx
+++ b/packages/basil/src/Type/Type.stories.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const types = [
   {
     name: 'canon',

--- a/packages/basil/src/Wayfinder/Wayfinder.stories.tsx
+++ b/packages/basil/src/Wayfinder/Wayfinder.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   Wayfinder,
   WayfinderItem,

--- a/packages/basil/src/Wayfinder/Wayfinder.stories.tsx
+++ b/packages/basil/src/Wayfinder/Wayfinder.stories.tsx
@@ -9,13 +9,13 @@ import {
 
 export default { title: 'Page|Wayfinder' };
 
-export const Level1Stub = () => (
+export const Level1Stub: React.FC = () => (
   <Wayfinder>
     <WayfinderTopLevel title={'Get involved'} to={'#'} />
   </Wayfinder>
 );
 
-export const Level1WithChildren = () => (
+export const Level1WithChildren: React.FC = () => (
   <Wayfinder>
     <WayfinderTopLevel title={'Get involved'} to={'#'}>
       <WayfinderItem to={'/sos'}>Societies</WayfinderItem>
@@ -25,7 +25,7 @@ export const Level1WithChildren = () => (
   </Wayfinder>
 );
 
-export const Level2WithChildren = () => (
+export const Level2WithChildren: React.FC = () => (
   <Wayfinder>
     <WayfinderTopLevel title={'Get involved'} to={'#'}>
       <WayfinderItem to={'/'}>Societies</WayfinderItem>
@@ -40,7 +40,7 @@ export const Level2WithChildren = () => (
   </Wayfinder>
 );
 
-export const Level3WithChildren = () => (
+export const Level3WithChildren: React.FC = () => (
   <Wayfinder>
     <WayfinderTopLevel title={'Get involved'} to={'#'}>
       <WayfinderItem to={'/'}>Societies</WayfinderItem>

--- a/packages/common/src/css/base.css
+++ b/packages/common/src/css/base.css
@@ -135,5 +135,3 @@ h4,
 .h4 {
   @mixin type pica;
 }
-
-@mixin outputTypeClassNames;

--- a/packages/common/src/defs/index.d.ts
+++ b/packages/common/src/defs/index.d.ts
@@ -2,6 +2,5 @@ export * from './graphql';
 export * from './htmr';
 export * from './json';
 export * from './react-countup';
-export * from './react-portal';
 export * from './react-stepper-primitive';
 export * from './svg';

--- a/packages/common/src/defs/react-portal.d.ts
+++ b/packages/common/src/defs/react-portal.d.ts
@@ -1,7 +1,0 @@
-declare module 'react-portal' {
-  class Portal extends React.Component<{
-    children: any;
-  }> {}
-
-  export { Portal };
-}

--- a/packages/common/src/libs/enumValues.ts
+++ b/packages/common/src/libs/enumValues.ts
@@ -1,2 +1,2 @@
-export const enumValues = (e: Object): number[] =>
+export const enumValues = (e: Record<string, any>): number[] =>
   Object.values(e).filter((v) => parseInt(v, 10) >= 0);

--- a/packages/common/src/libs/features/hasTouch.ts
+++ b/packages/common/src/libs/features/hasTouch.ts
@@ -1,12 +1,7 @@
-export function hasTouch() {
+export function hasTouch(): boolean {
   return 'ontouchstart' in window ||
-    // @ts-ignore
-    ((window as any).DocumentTouch && document instanceof DocumentTouch) ||
-    ((window as any).hasOwnProperty &&
-      ((window as any).hasOwnProperty('ontouchstart') ||
-        // @ts-ignore
-        ((window as any).DocumentTouch && document instanceof DocumentTouch) ||
-        navigator.msMaxTouchPoints))
+    (window.hasOwnProperty &&
+      (window.hasOwnProperty('ontouchstart') || navigator.msMaxTouchPoints))
     ? !0
     : 'ontouchstart' in window
     ? !0

--- a/packages/common/src/libs/flatStreamToLevels.ts
+++ b/packages/common/src/libs/flatStreamToLevels.ts
@@ -14,7 +14,7 @@ interface ResultTree {
 // use in Wagtail StreamField handling
 export default function flatStreamToLevels(
   itemToLevelFunc: ItemLevelVistor,
-  flatItemArray: Object[],
+  flatItemArray: Record<string, any>[],
 ) {
   // holds our index pointer for each level
   let lastLevel: number[] = [];
@@ -48,7 +48,7 @@ export default function flatStreamToLevels(
     return get(result, path);
   }
 
-  flatItemArray.forEach((item: Object) => {
+  flatItemArray.forEach((item: Record<string, any>) => {
     const level = itemToLevelFunc(item);
     const resultLevel = getPathForLevel(level);
     resultLevel.push({ ...item, _children: [] });

--- a/packages/common/src/libs/getFalmerEndpoint.ts
+++ b/packages/common/src/libs/getFalmerEndpoint.ts
@@ -1,4 +1,4 @@
-export default function getFalmerEndpoint() {
+export default function getFalmerEndpoint(): string {
   const serverSide = typeof localStorage === 'undefined';
 
   const clientEndpoint = serverSide

--- a/packages/common/src/libs/getMslJwt.ts
+++ b/packages/common/src/libs/getMslJwt.ts
@@ -1,7 +1,7 @@
-export function getMslJwt() {
+export function getMslJwt(): string | false {
   return (
     localStorage.getItem('MSL_JWT_OVERRIDE') ||
-    ((window as any).mslUserInfo && (window as any).mslUserInfo.jwt) ||
+    (window.mslUserInfo && window.mslUserInfo.jwt) ||
     false
   );
 }

--- a/packages/common/src/libs/hacky.ts
+++ b/packages/common/src/libs/hacky.ts
@@ -1,4 +1,4 @@
-export function removePageContainer() {
+export function removePageContainer(): void {
   const pageContainer = document.querySelector(
     '.js-page-container.LokiContainer',
   );

--- a/packages/common/src/libs/logError.ts
+++ b/packages/common/src/libs/logError.ts
@@ -1,6 +1,6 @@
 import Raven from 'raven-js';
 
-export default function logException(ex: Error, context: any) {
+export default function logException(ex: Error, context: any): void {
   Raven.captureException(ex, {
     extra: context,
   });

--- a/packages/common/src/libs/money.ts
+++ b/packages/common/src/libs/money.ts
@@ -1,3 +1,3 @@
-export function formatPrice(price: number) {
-  return price % 1 > 0 ? price.toFixed(2) : price.toString();
+export function formatPrice(price: number): string {
+  return price % 1 > 0 ? price.toFixed(2).toString() : price.toString();
 }

--- a/packages/common/src/libs/pageDataCollectors/shopBasket.ts
+++ b/packages/common/src/libs/pageDataCollectors/shopBasket.ts
@@ -1,1 +1,3 @@
-export function getBasketData() {}
+export function getBasketData(): void {
+  /* currently unused */
+}

--- a/packages/common/src/libs/store.ts
+++ b/packages/common/src/libs/store.ts
@@ -1,16 +1,18 @@
-let Store: IStore;
-
-interface IStore {
+interface Store {
   get(key: string, def: any): any;
   set(key: string, value: any): void;
 }
 
+let Store: Store;
+
 if (process.env.COMP_NODE) {
   Store = {
-    get(): any {
+    get() {
       return '';
     },
-    set(): void {},
+    set() {
+      /* do nothing */
+    },
   };
 } else {
   Store = {

--- a/packages/common/src/types/slates.ts
+++ b/packages/common/src/types/slates.ts
@@ -35,7 +35,7 @@ export interface InternalSlate {
 }
 
 export interface SlateBox {
-  component: any;
+  component: React.FC;
   displayName: string;
   category: string;
   schema: any;

--- a/packages/common/src/types/slates.ts
+++ b/packages/common/src/types/slates.ts
@@ -35,7 +35,7 @@ export interface InternalSlate {
 }
 
 export interface SlateBox {
-  component: React.FC;
+  component: React.FC<any>;
   displayName: string;
   category: string;
   schema: any;

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -5,4 +5,14 @@ export interface Profile {
   uuid: string;
 }
 
+export interface MSLUserInfo {
+  jwt?: string;
+  userinfo: {
+    IdCardNumber: string;
+    FirstName: string;
+    LastName: string;
+    UniqueId: string;
+  };
+}
+
 export type LogoutFn = () => void;

--- a/packages/comp/src/renderer.tsx
+++ b/packages/comp/src/renderer.tsx
@@ -30,7 +30,7 @@ export const renderHtml = (
     };
   }
 
-  let additionalHead = [];
+  const additionalHead = [];
 
   if (other.compOptions) {
     additionalHead.push(other.compOptions);

--- a/packages/falmer/src/components/FalmerDataList/index.tsx
+++ b/packages/falmer/src/components/FalmerDataList/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 
-interface IRowProps {
+interface RowProps {
   id?: number;
   key?: number;
   selectable: boolean;
@@ -15,14 +15,14 @@ interface Item {
   id: number;
 }
 
-interface IProps {
-  header(args: IRowProps): any;
+interface FalmerDataListProps {
+  header(args: RowProps): any;
   selectable: boolean;
   items: Item[];
-  children(item: Item, props: IRowProps): any;
+  children(item: Item, props: RowProps): any;
 }
 
-const FalmerDataList: React.FC<IProps> = ({
+const FalmerDataList: React.FC<FalmerDataListProps> = ({
   header,
   selectable,
   items,
@@ -69,7 +69,7 @@ export const HeaderCell: React.FC<{}> = (props) => {
   return <th>{props.children}</th>;
 };
 
-export const Row: React.FC<IRowProps> = (props) => {
+export const Row: React.FC<RowProps> = (props) => {
   return (
     <tr className="FalmerDataList__row" key={props.id}>
       {props.selectable ? (

--- a/packages/falmer/src/components/FalmerHeader/index.tsx
+++ b/packages/falmer/src/components/FalmerHeader/index.tsx
@@ -29,7 +29,7 @@ const FalmerHeader: React.FC = () => {
         title="Sussex Students' Union"
       >
         <StudentsUnionLogoNoLogotype />
-        <span className="u-h">Sussex Students' Union</span>
+        <span className="u-h">{`Sussex Students' Union`}</span>
       </div>
       <h1 css={logotypeStyle}>Falmer</h1>
       <nav className="FalmerHeader__nav">

--- a/packages/falmer/src/components/FalmerSidebar/index.tsx
+++ b/packages/falmer/src/components/FalmerSidebar/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-interface IProps {}
-
-const FalmerSidebar: React.FC<IProps> = (props) => {
+const FalmerSidebar: React.FC = (props) => {
   return <aside className="FalmerSidebar">{props.children}</aside>;
 };
 

--- a/packages/falmer/src/components/ImageTreatmentPreview/index.tsx
+++ b/packages/falmer/src/components/ImageTreatmentPreview/index.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { FalmerImage } from '@ussu/common/src/types/events';
 import { AspectRatio, OneImage } from '@ussu/website/src/components/OneImage';
 
-interface IProps {
+interface ImageTreatmentPreviewProps {
   image: FalmerImage;
 }
 
-const ImageTreatmentPreview: React.FC<IProps> = ({ image }) => {
+const ImageTreatmentPreview: React.FC<ImageTreatmentPreviewProps> = ({
+  image,
+}) => {
   const treatments = [
     {
       size: AspectRatio.r1by1,

--- a/packages/falmer/src/containers/FalmerApplication/index.tsx
+++ b/packages/falmer/src/containers/FalmerApplication/index.tsx
@@ -50,7 +50,7 @@ export const FalmerApplication: React.FC = () => {
 
   useEffect(() => {
     dispatch(requestAuthToken());
-  }, []);
+  }, [dispatch]);
 
   if (auth.loading) {
     return <Loader />;

--- a/packages/falmer/src/containers/FalmerFeaturedAreas/FalmerSlateDetail/index.tsx
+++ b/packages/falmer/src/containers/FalmerFeaturedAreas/FalmerSlateDetail/index.tsx
@@ -7,13 +7,15 @@ import { RouteComponentProps } from 'react-router';
 import { SlateEditor } from '../SlateEditor';
 import { InternalSlate } from '@ussu/common/src/types/slates';
 
-interface IProps extends RouteComponentProps<{ slateId: string | undefined }> {}
+type FalmerSlateDetailProps = RouteComponentProps<{
+  slateId: string | undefined;
+}>;
 
 interface Result {
   slate: InternalSlate;
 }
 
-export const FalmerSlateDetail: React.FC<IProps> = ({
+export const FalmerSlateDetail: React.FC<FalmerSlateDetailProps> = ({
   match: {
     params: { slateId },
   },

--- a/packages/falmer/src/containers/FalmerFeaturedAreas/SlateEditor.tsx
+++ b/packages/falmer/src/containers/FalmerFeaturedAreas/SlateEditor.tsx
@@ -121,7 +121,7 @@ const EditableArea: React.FC<{
         'mediaId',
       );
     },
-    [area],
+    [usedImages],
   );
   const imageData = useMappedState(mapState);
 
@@ -178,26 +178,29 @@ export const SlateEditor: React.FC<Props> = ({ data, onSave }) => {
 
   const handleSave = useCallback(() => {
     onSave(editorData);
-  }, [editorData]);
+  }, [editorData, onSave]);
 
-  const changeLayout = useCallback((layout: Layout) => {
-    const currentData = editorData !== null ? editorData : data;
+  const changeLayout = useCallback(
+    (layout: Layout) => {
+      const currentData = editorData !== null ? editorData : data;
 
-    updateSelectedArea(0);
-    updateEditorData({
-      layout,
-      areas: new Array(AreasMap[layout]).fill(null).map((_: any, i: number) =>
-        currentData.areas[i] !== undefined
-          ? currentData.areas[i]
-          : [
-              {
-                type: BoxType.NA,
-                data: {},
-              },
-            ],
-      ),
-    });
-  }, []);
+      updateSelectedArea(0);
+      updateEditorData({
+        layout,
+        areas: new Array(AreasMap[layout]).fill(null).map((_: any, i: number) =>
+          currentData.areas[i] !== undefined
+            ? currentData.areas[i]
+            : [
+                {
+                  type: BoxType.NA,
+                  data: {},
+                },
+              ],
+        ),
+      });
+    },
+    [data, editorData],
+  );
 
   const changeBox = useCallback((selectedArea: any, box: BoxType) => {
     updateEditorData(
@@ -218,7 +221,7 @@ export const SlateEditor: React.FC<Props> = ({ data, onSave }) => {
 
   useEffect(() => {
     changeLayout(data.layout);
-  }, []);
+  }, [changeLayout, data.layout]);
 
   if (editorData === null) {
     return null;

--- a/packages/falmer/src/containers/FalmerMedia/FalmerMediaDetail/index.tsx
+++ b/packages/falmer/src/containers/FalmerMedia/FalmerMediaDetail/index.tsx
@@ -6,13 +6,15 @@ import { FalmerImage } from '@ussu/common/src/types/events';
 import { useQuery } from '@apollo/react-hooks';
 import { RouteComponentProps } from 'react-router';
 
-interface IProps extends RouteComponentProps<{ mediaId: string | undefined }> {}
+type FalmerMediaDetailProps = RouteComponentProps<{
+  mediaId: string | undefined;
+}>;
 
 interface Result {
   image: FalmerImage;
 }
 
-const FalmerMediaDetail: React.FC<IProps> = ({
+const FalmerMediaDetail: React.FC<FalmerMediaDetailProps> = ({
   match: {
     params: { mediaId },
   },

--- a/packages/falmer/src/containers/FalmerSelectEvent/index.tsx
+++ b/packages/falmer/src/containers/FalmerSelectEvent/index.tsx
@@ -11,7 +11,7 @@ import { Connection } from '@ussu/common/src/types/falmer';
 import { Event } from '@ussu/common/src/types/events';
 import { useQuery } from '@apollo/react-hooks';
 
-interface IProps {
+interface FalmerEventsProps {
   onSelect(eventId: number): void;
 }
 
@@ -19,7 +19,7 @@ interface Result {
   allEvents: Connection<Event>;
 }
 
-const FalmerEvents: React.FC<IProps> = ({ onSelect }) => {
+const FalmerEvents: React.FC<FalmerEventsProps> = ({ onSelect }) => {
   const { data, loading } = useQuery<Result>(ALL_EVENTS_QUERY);
 
   if (loading || !data) {

--- a/packages/falmer/src/containers/FalmerStudentGroups/FalmerStudentGroupsDetail/index.tsx
+++ b/packages/falmer/src/containers/FalmerStudentGroups/FalmerStudentGroupsDetail/index.tsx
@@ -8,7 +8,7 @@ import { FalmerDetailHeader } from '../../../components/FalmerDetailHeader';
 import { useQuery } from '@apollo/react-hooks';
 import { StudentGroup } from '@ussu/common/src/types/groups';
 
-interface IProps {
+interface FalmerStudentGroupsDetailProps {
   groupId: number;
 }
 
@@ -16,7 +16,9 @@ interface Result {
   group: StudentGroup;
 }
 
-const FalmerStudentGroupsDetail: React.FC<IProps> = ({ groupId }) => {
+const FalmerStudentGroupsDetail: React.FC<FalmerStudentGroupsDetailProps> = ({
+  groupId,
+}) => {
   const { data, loading } = useQuery<Result>(GROUP_DETAIL_QUERY, {
     variables: { groupId },
   });

--- a/packages/falmer/src/defs/react-portal.d.ts
+++ b/packages/falmer/src/defs/react-portal.d.ts
@@ -1,7 +1,0 @@
-declare module 'react-portal' {
-  class Portal extends React.Component<{
-    children: any;
-  }> {}
-
-  export { Portal };
-}

--- a/packages/falmer/src/ducks/utils.ts
+++ b/packages/falmer/src/ducks/utils.ts
@@ -1,4 +1,4 @@
-export function apiQuery(query: Object, variables = {}) {
+export function apiQuery(query: Record<string, any>, variables = {}) {
   const token = localStorage.getItem('token');
   return fetch('/graphql/', {
     method: 'POST',

--- a/packages/react-swipe-card/src/SimpleCard.tsx
+++ b/packages/react-swipe-card/src/SimpleCard.tsx
@@ -47,7 +47,7 @@ export const SimpleCard: React.FC<SimpleCardProps> = (props) => {
 
   const { initialPosition } = state;
   const { styleTransformer, shouldTransition, isPristine } = props;
-  var style = {
+  const style = {
     ...styleTransformer(initialPosition, initialPosition),
     zIndex: 10 - props.index,
     ...props.style,

--- a/packages/website/src/application.ts
+++ b/packages/website/src/application.ts
@@ -15,11 +15,6 @@ Raven.config('https://fd478822b69843a2a3718c621c5fadad@sentry.io/158659', {
 // probs not great
 (window as any).emitter = mitt();
 
-(window as any).LinkshimAsyncLink = {
-  referrer_log() {},
-  swap() {},
-};
-
 const siteMode = getSiteMode();
 
 if (siteMode === Mode.Top || siteMode === Mode.ExternalFrame) {

--- a/packages/website/src/components/AboutTheUnion/index.tsx
+++ b/packages/website/src/components/AboutTheUnion/index.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 
-export const AboutTheUnion = () => (
+export const AboutTheUnion: React.FC = () => (
   <div className="FUnion">
     <div className="LokiContainer">
-      <h2 className="ContentBlock__heading">We're your Students' Union</h2>
+      <h2 className="ContentBlock__heading">{`We're your Students' Union`}</h2>
       <div>
-        <p>You'll automatically become a member of the Students' Union.</p>
+        <p>{`You'll automatically become a member of the Students' Union.`}</p>
         <p>
-          We are a community of over 18,000 students and you're a member of that
-          community when you study at Sussex or BSMS.
+          {`We are a community of over 18,000 students and you're a member of that
+          community when you study at Sussex or BSMS.`}
         </p>
         <p>
-          Independent from the University, we are undergraduates, postgraduates,
+          {`Independent from the University, we are undergraduates, postgraduates,
           mature students, parents, international students, elected Students'
           Union officers, volunteers and staff. We're sports team members,
           Student Reps, campaigners, society committee members, event attendees,
-          shoppers and bargain hunters. We're all of our 18,000 members.{' '}
+          shoppers and bargain hunters. We're all of our 18,000 members.`}
         </p>
       </div>
     </div>

--- a/packages/website/src/components/AdvertBar/MSLAdvert.tsx
+++ b/packages/website/src/components/AdvertBar/MSLAdvert.tsx
@@ -5,7 +5,7 @@ interface MSLAdvertProps {
   position: string;
 }
 
-export const MSLAdvert = ({ position }: MSLAdvertProps) => (
+export const MSLAdvert: React.FC<MSLAdvertProps> = ({ position }) => (
   <div
     className="AdvertBar__advert"
     dangerouslySetInnerHTML={{

--- a/packages/website/src/components/AdvertBar/index.tsx
+++ b/packages/website/src/components/AdvertBar/index.tsx
@@ -4,7 +4,6 @@ import cx from 'classnames';
 interface AdvertBarProps {
   className?: string;
   dark?: boolean;
-  children: any;
 }
 
 export const AdvertBar: React.FC<AdvertBarProps> = ({

--- a/packages/website/src/components/BackBar/index.tsx
+++ b/packages/website/src/components/BackBar/index.tsx
@@ -4,7 +4,6 @@ import cx from 'classnames';
 interface BackBarProps {
   color?: 'red' | 'blue' | 'green' | 'slate';
   href: string;
-  children: any;
 }
 
 export const BackBar: React.FC<BackBarProps> = ({

--- a/packages/website/src/components/BreadcrumbBar/BreadcrumbBar.stories.tsx
+++ b/packages/website/src/components/BreadcrumbBar/BreadcrumbBar.stories.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-// @ts-ignore
-import { withKnobs, number } from '@storybook/addon-knobs/react';
 import { BreadcrumbBar } from './index';
 
 const crumbs = [
@@ -19,14 +17,6 @@ const crumbs = [
   </a>,
 ];
 
-storiesOf('BreadcrumbBar', module)
-  .addDecorator(withKnobs)
-  .add('default', () => {
-    const level = number('levels', 3, {
-      range: true,
-      min: 1,
-      max: crumbs.length,
-      step: 1,
-    });
-    return <BreadcrumbBar>{crumbs.slice(0, level)}</BreadcrumbBar>;
-  });
+storiesOf('BreadcrumbBar', module).add('default', () => {
+  return <BreadcrumbBar>{crumbs.slice(0, 3)}</BreadcrumbBar>;
+});

--- a/packages/website/src/components/BreadcrumbBar/index.tsx
+++ b/packages/website/src/components/BreadcrumbBar/index.tsx
@@ -4,9 +4,7 @@ import ChevronForwardIcon from '@ussu/common/src/icons/chevron-forward.svg';
 import { InternalAppLink } from '../InternalAppLink';
 import { css } from '@emotion/core';
 
-interface IProps {}
-
-const BreadcrumbBar: React.FC<IProps> = ({ children }) => {
+const BreadcrumbBar: React.FC = ({ children }) => {
   return (
     <ul
       css={css({
@@ -64,11 +62,11 @@ function generateBreadcrumbsFromPage(page: any) {
   );
 }
 
-interface IContentProps extends IProps {
+interface ContentBreadcrumbBarProps {
   page: any;
 }
 
-const ContentBreadcrumbBar = (props: IContentProps) => {
+const ContentBreadcrumbBar: React.FC<ContentBreadcrumbBarProps> = (props) => {
   return (
     <BreadcrumbBar {...omit(props, ['children'])}>
       {generateBreadcrumbsFromPage(props.page)}

--- a/packages/website/src/components/Button/index.tsx
+++ b/packages/website/src/components/Button/index.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import cx from 'classnames';
 
-interface IProps {
+interface ButtonProps {
   href: string;
-  children: any;
   endOfCard?: boolean;
 }
 
-export const Button: React.FC<IProps> = ({
+export const Button: React.FC<ButtonProps> = ({
   href,
   endOfCard = false,
   children,

--- a/packages/website/src/components/ContentNavigation/index.tsx
+++ b/packages/website/src/components/ContentNavigation/index.tsx
@@ -10,7 +10,7 @@ interface Section {
   children: Section[];
 }
 
-interface IProps {
+interface ContentNavigationProps {
   title?: string;
   items: Section[];
   activeKey?: string;
@@ -39,7 +39,7 @@ function canDisplaySubMenu(
 
 // TODO: Tidy this up. Should technically support unlimited levels
 // TODO: this component's name doesn't match the css component
-export const ContentNavigation: React.FC<IProps> = ({
+export const ContentNavigation: React.FC<ContentNavigationProps> = ({
   title,
   items,
   activeKey = '',

--- a/packages/website/src/components/CopyToClipboardButton/index.tsx
+++ b/packages/website/src/components/CopyToClipboardButton/index.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
-interface IProps {
+interface CopyToClipboardButtonProps {
   value: string;
 }
 
-export const CopyToClipboardButton: React.FC<IProps> = ({
+export const CopyToClipboardButton: React.FC<CopyToClipboardButtonProps> = ({
   value,
   children,
 }) => {

--- a/packages/website/src/components/Deckchair/index.tsx
+++ b/packages/website/src/components/Deckchair/index.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
 
-interface IProps {
+interface DeckchairProps {
   header: string;
   about: string;
   chairKey?: string;
   color: string;
-  children?: any;
 }
 
-export const Deckchair: React.FC<IProps> = ({
+export const Deckchair: React.FC<DeckchairProps> = ({
   header,
   about,
   chairKey,
   color,
   children,
-}: IProps) => (
+}) => (
   <div className={`Deckchair Deckchair--color-${color}`} data-chair={chairKey}>
     {chairKey ? <div className="Deckchair__close" /> : null}
     <div className="Deckchair__info">

--- a/packages/website/src/components/ErrorBoundary/index.tsx
+++ b/packages/website/src/components/ErrorBoundary/index.tsx
@@ -4,7 +4,6 @@ import { withRouter, RouteComponentProps } from 'react-router';
 import Raven from 'raven-js';
 
 interface ErrorBoundaryProps extends RouteComponentProps<any> {
-  children?: any;
   FallbackComponent?: any;
   onError?: (error: Error, componentStack: string) => void;
 }

--- a/packages/website/src/components/ErrorState/index.tsx
+++ b/packages/website/src/components/ErrorState/index.tsx
@@ -4,8 +4,9 @@ import Raven from 'raven-js';
 import { type, TypeSize } from '@ussu/basil/src/style/type';
 import { COLORS } from '@ussu/basil/src/style';
 
-const refreshPage = () =>
+const refreshPage = (): void => {
   typeof window !== 'undefined' && window.location.reload();
+};
 
 interface ErrorStateProps {
   title?: string;

--- a/packages/website/src/components/FauxInternalAppLink/index.tsx
+++ b/packages/website/src/components/FauxInternalAppLink/index.tsx
@@ -5,13 +5,10 @@ export default ({ href }: { href: string }) => (
   <InternalAppLink className="u-faux-link" to={href} />
 );
 
-export const InnerLink = ({
-  className = '',
-  ...props
-}: {
+export const InnerLink: React.FC<{
   to: string;
   [attr: string]: any;
-}) => (
+}> = ({ className = '', ...props }) => (
   <InternalAppLink {...props} className={`u-faux-link-inner ${className}`}>
     {props.children}
   </InternalAppLink>

--- a/packages/website/src/components/FauxLink/index.tsx
+++ b/packages/website/src/components/FauxLink/index.tsx
@@ -4,11 +4,14 @@ export default ({ href }: { href: string }) => (
   <a className="u-faux-link" href={href} />
 );
 
-interface IInnerLinkProp extends React.AnchorHTMLAttributes<any> {
+interface InnerLinkProp extends React.AnchorHTMLAttributes<any> {
   className: string;
 }
 
-export const InnerLink = ({ className = '', ...props }: IInnerLinkProp) => (
+export const InnerLink: React.FC<InnerLinkProp> = ({
+  className = '',
+  ...props
+}) => (
   <a {...props} className={`u-faux-link-inner ${className}`}>
     {props.children}
   </a>

--- a/packages/website/src/components/FauxRouterLink/index.tsx
+++ b/packages/website/src/components/FauxRouterLink/index.tsx
@@ -10,13 +10,10 @@ export const FauxRouterLinkNonIAL = ({ href }: { href: string }) => (
   <Link className="u-faux-link" to={href} />
 );
 
-export const InnerLink = ({
-  className = '',
-  ...props
-}: {
+export const InnerLink: React.FC<{
   to: string;
   [attr: string]: any;
-}) => (
+}> = ({ className = '', ...props }) => (
   <InternalAppLink {...props} className={`u-faux-link-inner ${className}`}>
     {props.children}
   </InternalAppLink>

--- a/packages/website/src/components/FigureCollection/FigureCollectionFigure.tsx
+++ b/packages/website/src/components/FigureCollection/FigureCollectionFigure.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { OneImage, AspectRatio } from '../OneImage';
 
-interface IProps {
+interface FigureCollectionFigureProps {
   imageResource: string;
   title: string;
   sub: string;
@@ -15,7 +15,7 @@ export interface FigureData {
   link: string;
 }
 
-export const FigureCollectionFigure: React.FC<IProps> = ({
+export const FigureCollectionFigure: React.FC<FigureCollectionFigureProps> = ({
   imageResource,
   title,
   sub,

--- a/packages/website/src/components/FigureCollection/index.tsx
+++ b/packages/website/src/components/FigureCollection/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { FigureCollectionFigure, FigureData } from './FigureCollectionFigure';
 
-interface IProps {
+interface FigureCollectionProps {
   items?: FigureData[];
   size?: 'small' | 'medium';
 }
 
-export const FigureCollection: React.FC<IProps> = ({
+export const FigureCollection: React.FC<FigureCollectionProps> = ({
   children,
   items = null,
   size = 'medium',

--- a/packages/website/src/components/HeadingHero/index.tsx
+++ b/packages/website/src/components/HeadingHero/index.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import cx from 'classnames';
 import { OneImageBackground } from '../OneImage';
 
-interface IProps {
+interface HeadingHeroProps {
   imageURL: string;
   title: string;
   description?: string;
   thin?: boolean;
 }
 
-export const HeadingHero: React.FC<IProps> = ({
+export const HeadingHero: React.FC<HeadingHeroProps> = ({
   imageURL,
   title,
   description = '',

--- a/packages/website/src/components/HeadingImage/index.tsx
+++ b/packages/website/src/components/HeadingImage/index.tsx
@@ -1,13 +1,13 @@
 // DEPRECIATED: Use ../HeadingHero
 import React from 'react';
 
-interface IProps {
+interface HeadingImageProps {
   imageURL: string;
   title: string;
   description?: string;
 }
 
-export const HeadingImage: React.FC<IProps> = ({
+export const HeadingImage: React.FC<HeadingImageProps> = ({
   imageURL,
   title,
   description,

--- a/packages/website/src/components/HomepageSplash/index.tsx
+++ b/packages/website/src/components/HomepageSplash/index.tsx
@@ -15,7 +15,7 @@ const placeholderHints = shuffle([
   'jobs',
 ]);
 
-const HomepageSplashComponent = () => (
+const HomepageSplashComponent: React.FC = () => (
   <OneImageBackground
     src="original_images/7ee2fc8daf2e4f93bea953d9e86c32ee"
     css={{

--- a/packages/website/src/components/JsonLd/index.tsx
+++ b/packages/website/src/components/JsonLd/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-export const JsonLd = ({ data }: { data: Object }) => (
+// eslint-disable-next-line
+export const JsonLd: React.FC<{ data: any }> = ({ data }) => (
   <script
     type="application/ld+json"
     dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}

--- a/packages/website/src/components/LoadableLoading/index.tsx
+++ b/packages/website/src/components/LoadableLoading/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Loader } from '../Loader/index';
 
-interface IProps {
+interface LoadingProps {
   error: null | Error;
   timedOut: boolean;
   pastDelay: boolean;
 }
 
-function Loading(props: IProps) {
+const Loading: React.FC<LoadingProps> = (props) => {
   if (props.error) {
     return <div>Error!</div>;
   }
@@ -21,7 +21,7 @@ function Loading(props: IProps) {
   }
 
   return null;
-}
+};
 
 export { Loading as LoadableLoading };
 

--- a/packages/website/src/components/Loader/index.tsx
+++ b/packages/website/src/components/Loader/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import cx from 'classnames';
 import LoaderLeaves from '@ussu/common/src/icons/loader.svg';
 
-interface IProps {
+interface LoaderProps {
   dark?: boolean;
 }
 
-export const Loader: React.FC<IProps> = (props) => {
+export const Loader: React.FC<LoaderProps> = (props) => {
   return (
     <div className={cx('Loader', { 'Loader--dark': props.dark })}>
       <LoaderLeaves className="Loader__svg" />

--- a/packages/website/src/components/LoginModal/index.tsx
+++ b/packages/website/src/components/LoginModal/index.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { Modal } from '../Modal';
 import { BannerOutlet } from '../BannerOutlet';
 
-interface LoginModalProps {}
-
-export const LoginModal: React.FC<LoginModalProps & ReactModal.Props> = (
-  props,
-) => {
+export const LoginModal: React.FC<ReactModal.Props> = (props) => {
   const currentPath =
     typeof window !== 'undefined' ? window.location.pathname : '/';
 

--- a/packages/website/src/components/LokiHeader/index.tsx
+++ b/packages/website/src/components/LokiHeader/index.tsx
@@ -39,7 +39,7 @@ export const LokiHeaderInner: React.FC = () => {
             title="Sussex Students' Union"
           >
             <StudentsUnionLogoNoLogotype />
-            <span className="u-h">Sussex Students' Union</span>
+            <span className="u-h">{`Sussex Students' Union`}</span>
           </InternalAppLink>
         </div>
         <div className="LokiHeader__parts">
@@ -76,7 +76,7 @@ export const LokiHeaderInner: React.FC = () => {
   );
 };
 
-export const LokiHeader = () => (
+export const LokiHeader: React.FC = () => (
   <header className="LokiHeader">
     <LokiHeaderInner />
   </header>

--- a/packages/website/src/components/LokiHeader/useHover.tsx
+++ b/packages/website/src/components/LokiHeader/useHover.tsx
@@ -19,7 +19,7 @@ export function useHover<T extends HTMLElement>(): [RefObject<T>, boolean] {
         node.removeEventListener('mouseout', handleMouseOut);
       };
     }
-  }, [ref.current]); // Recall only if ref changes
+  }, []); // Recall only if ref changes
 
   return [ref, value];
 }

--- a/packages/website/src/components/LokiMenu/index.tsx
+++ b/packages/website/src/components/LokiMenu/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { InternalAppLink } from '../InternalAppLink';
 
-interface IPropsItem {
+interface PropsItem {
   name: string;
   link: string;
 }
 
-const LokiMenuItem = ({ name, link }: IPropsItem) => (
+const LokiMenuItem: React.FC<PropsItem> = ({ name, link }) => (
   <li className="LokiMenu__item">
     <InternalAppLink className="LokiMenu__link" to={link}>
       {name}

--- a/packages/website/src/components/Modal/index.tsx
+++ b/packages/website/src/components/Modal/index.tsx
@@ -9,9 +9,7 @@ interface EnchancedModalProps {
   footerClose?: boolean;
 }
 
-const Modal = (
-  props: ReactModal.Props & EnchancedModalProps & { children: any },
-) => (
+const Modal: React.FC<ReactModal.Props & EnchancedModalProps> = (props) => (
   <ReactModal
     closeTimeoutMS={300}
     css={[

--- a/packages/website/src/components/NewsList/NewsBlock.tsx
+++ b/packages/website/src/components/NewsList/NewsBlock.tsx
@@ -17,11 +17,11 @@ export interface NewsItem {
   imageURL?: string;
 }
 
-interface IProps {
+interface NewsBlockProps {
   item: NewsItem;
 }
 
-export const NewsBlock: React.FC<IProps> = ({
+export const NewsBlock: React.FC<NewsBlockProps> = ({
   item: { title, link, publishedDate, led, imageURL },
 }) => (
   <li

--- a/packages/website/src/components/NewsList/index.tsx
+++ b/packages/website/src/components/NewsList/index.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import cx from 'classnames';
 import { NewsBlock, NewsItem } from './NewsBlock';
 
-interface IProps {
+interface NewslistProps {
   fullWidth?: boolean;
   items: NewsItem[];
 }
 
-export const NewsList: React.FC<IProps> = ({ items, fullWidth = false }) => (
+export const NewsList: React.FC<NewslistProps> = ({
+  items,
+  fullWidth = false,
+}) => (
   <ul className={cx('NewsGrid', { 'NewsGrid--full-width': fullWidth })}>
     {items.map((item) => (
       <NewsBlock item={item} key={item.id} />

--- a/packages/website/src/components/NewsletterSignup/index.tsx
+++ b/packages/website/src/components/NewsletterSignup/index.tsx
@@ -51,10 +51,7 @@ const RESPONSE_TEXT: {
     `We either haven't been able to add you or you might already be on there. Please try again later.`,
 };
 
-class NewsletterSignup extends React.Component<
-  undefined,
-  NewsletterSignupState
-> {
+class NewsletterSignup extends React.Component<{}, NewsletterSignupState> {
   private handleFormSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   private handleEmailAddress: (e: React.ChangeEvent<HTMLInputElement>) => void;
   private handleName: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -62,7 +59,7 @@ class NewsletterSignup extends React.Component<
   private handleNameSubmit: () => void;
   private handleLevel: (level: string) => void;
 
-  constructor(props: undefined) {
+  constructor(props: {}) {
     super(props);
 
     this.state = Object.assign(

--- a/packages/website/src/components/NewsletterSignup/index.tsx
+++ b/packages/website/src/components/NewsletterSignup/index.tsx
@@ -26,9 +26,7 @@ enum FormState {
   Error = 'Error',
 }
 
-interface IProps {}
-
-interface IState {
+interface NewsletterSignupState {
   currentState: FormState;
   isLoading: boolean;
   continuationToken: string;
@@ -40,7 +38,7 @@ interface IState {
 }
 
 const RESPONSE_TEXT: {
-  [state: string]: (data: IState['data']) => string;
+  [state: string]: (data: NewsletterSignupState['data']) => string;
 } = {
   [FormState.Initial]: () => `Sign up to our newsletter for exclusive content`,
   [FormState.InitialFocus]: () => `Enter your email address`,
@@ -53,7 +51,10 @@ const RESPONSE_TEXT: {
     `We either haven't been able to add you or you might already be on there. Please try again later.`,
 };
 
-class NewsletterSignup extends React.Component<IProps, IState> {
+class NewsletterSignup extends React.Component<
+  undefined,
+  NewsletterSignupState
+> {
   private handleFormSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   private handleEmailAddress: (e: React.ChangeEvent<HTMLInputElement>) => void;
   private handleName: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -61,7 +62,7 @@ class NewsletterSignup extends React.Component<IProps, IState> {
   private handleNameSubmit: () => void;
   private handleLevel: (level: string) => void;
 
-  constructor(props: IProps) {
+  constructor(props: undefined) {
     super(props);
 
     this.state = Object.assign(
@@ -120,7 +121,10 @@ class NewsletterSignup extends React.Component<IProps, IState> {
         });
     };
 
-    const fieldUpdate = (nextSuccessState: FormState, fieldMap: Object) => {
+    const fieldUpdate = (
+      nextSuccessState: FormState,
+      fieldMap: Record<string, any>,
+    ) => {
       fetch(NEWSLETTER_ENDPOINT, {
         method: 'PATCH',
         headers: {
@@ -233,7 +237,7 @@ class NewsletterSignup extends React.Component<IProps, IState> {
             <div className="NewsletterSignup__form">
               <ul className="NewsletterSignup__options">
                 {Object.keys(OPTIONS_MERGE.LEVEL).map((key) => (
-                  <li className="NewsletterSignup__options-item">
+                  <li key={key} className="NewsletterSignup__options-item">
                     <button
                       type="button"
                       className="NewsletterSignup__options-button"

--- a/packages/website/src/components/Offers/index.tsx
+++ b/packages/website/src/components/Offers/index.tsx
@@ -68,7 +68,7 @@ export const Offers: React.FC = () => {
           <h2>{data.allOffers[openOffer].dealTag}</h2>
           {data.allOffers[openOffer].companyWebsite ? (
             <Button href={data.allOffers[openOffer].companyWebsite}>
-              View website >
+              {`View website >`}
             </Button>
           ) : null}
           <StreamField page={{}} items={data.allOffers[openOffer].main} />

--- a/packages/website/src/components/OneImage/index.tsx
+++ b/packages/website/src/components/OneImage/index.tsx
@@ -25,7 +25,7 @@ interface ImageOptions {
   [optionName: string]: number | string;
 }
 
-interface IProps extends React.HTMLAttributes<HTMLImageElement> {
+interface OneImageProps extends React.HTMLAttributes<HTMLImageElement> {
   aspectRatio: AspectRatioInput;
   src: string;
   alt: string;
@@ -37,7 +37,10 @@ interface IProps extends React.HTMLAttributes<HTMLImageElement> {
   mediaSizes?: string;
 }
 
-function aspectMultiplier(aspectRatio: AspectRatioInput, width: number) {
+function aspectMultiplier(
+  aspectRatio: AspectRatioInput,
+  width: number,
+): number {
   if (typeof aspectRatio === 'string') {
     return width * aspectRatioMap[aspectRatio];
   }
@@ -52,7 +55,7 @@ const defaultOptions = {
   crop: 'faces',
 };
 
-function createQueryString(obj: { [key: string]: any }) {
+function createQueryString(obj: { [key: string]: string | number }): string {
   return Object.entries(obj)
     .map((pair) => pair.join('='))
     .join('&');
@@ -66,7 +69,7 @@ function generateUrl(
     options?: ImageOptions;
   },
   opts: { width: number },
-) {
+): string {
   if (!props.aspectRatio) {
     return `${props.mslResource ? MSL_ENDPOINT : FALMER_ENDPOINT}${
       props.src
@@ -93,7 +96,7 @@ const defaultSizes = [
   1680,
 ];
 
-const OneImage: React.FC<IProps> = (props) => {
+const OneImage: React.FC<OneImageProps> = (props) => {
   const containerRef = useRef<null | HTMLImageElement>(null);
 
   useLayoutEffect(() => {
@@ -138,13 +141,14 @@ const OneImage: React.FC<IProps> = (props) => {
   return <div {...containerProps}>{img}</div>;
 };
 
-export interface IBackgroundProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface OneImageBackgroundProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   aspectRatio?: AspectRatioInput;
   src: string;
   mslResource?: boolean;
 }
 
-const OneImageBackground: React.FC<IBackgroundProps> = (props) => {
+const OneImageBackground: React.FC<OneImageBackgroundProps> = (props) => {
   const containerRef = useRef<null | HTMLDivElement>(null);
 
   useLayoutEffect(() => {

--- a/packages/website/src/components/OrganisationCard/index.tsx
+++ b/packages/website/src/components/OrganisationCard/index.tsx
@@ -3,11 +3,11 @@ import { PatternPlaceholder } from '../PatternPlaceholder';
 import { AspectRatio, OneImage } from '../OneImage';
 import { StudentGroup } from '@ussu/common/src/types/groups';
 
-interface IProps {
+interface OrganisationCardProps {
   org: StudentGroup;
 }
 
-export const OrganisationCard: React.FC<IProps> = (props: IProps) => {
+export const OrganisationCard: React.FC<OrganisationCardProps> = (props) => {
   const org = props.org;
   return (
     <li className="TrailGrid__item">

--- a/packages/website/src/components/OrganisationGrid/index.tsx
+++ b/packages/website/src/components/OrganisationGrid/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { OrganisationCard } from '../OrganisationCard';
 import { StudentGroup } from '@ussu/common/src/types/groups';
 
-interface IProps {
+interface OrganisationGridProps {
   organisations: StudentGroup[];
 }
 
-export const OrganisationGrid: React.FC<IProps> = (props: IProps) => {
+export const OrganisationGrid: React.FC<OrganisationGridProps> = (props) => {
   const { organisations } = props;
   return (
     <ul className="TrailGrid TrailGrid--large">

--- a/packages/website/src/components/PaginationNavigation/index.tsx
+++ b/packages/website/src/components/PaginationNavigation/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-interface IProps {
+interface PaginationNavigationProps {
   currentPage: number;
   totalPages: number;
   onPageChange(pageNumber: number): void;
 }
 
-export const PaginationNavigation: React.FC<IProps> = ({
+export const PaginationNavigation: React.FC<PaginationNavigationProps> = ({
   currentPage,
   totalPages,
   onPageChange,

--- a/packages/website/src/components/PersonCollection/PersonCollectionFigure.tsx
+++ b/packages/website/src/components/PersonCollection/PersonCollectionFigure.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { OneImage, AspectRatio } from '../OneImage';
 
-interface IProps {
+interface PersonCollectionFigureProps {
   imageResource: string;
   title: string;
   sub: string;
@@ -15,12 +15,12 @@ export interface FigureData {
   link: string;
 }
 
-export const PersonCollectionFigure = ({
+export const PersonCollectionFigure: React.FC<PersonCollectionFigureProps> = ({
   imageResource,
   title,
   sub,
   link,
-}: IProps) => (
+}) => (
   <li className="PersonCollection__item">
     <a href={link} className="PersonCollection__link">
       <div className="PersonCollection__image">

--- a/packages/website/src/components/PersonCollection/index.tsx
+++ b/packages/website/src/components/PersonCollection/index.tsx
@@ -4,18 +4,20 @@ import {
   FigureData,
 } from '../PersonCollection/PersonCollectionFigure';
 
-interface IProps {
+interface PersonCollectionProps {
   items?: FigureData[];
   size?: 'small' | 'medium' | 'big';
 }
 
-export const PersonCollection: React.FC<IProps> = ({
+export const PersonCollection: React.FC<PersonCollectionProps> = ({
   children,
   items = null,
 }) => (
   <ul className={`PersonCollection`}>
     {items === null
       ? children
-      : items.map((item) => <PersonCollectionFigure {...item} />)}
+      : items.map((item) => (
+          <PersonCollectionFigure key={item.link} {...item} />
+        ))}
   </ul>
 );

--- a/packages/website/src/components/PrefooterMenu/index.tsx
+++ b/packages/website/src/components/PrefooterMenu/index.tsx
@@ -1,23 +1,22 @@
 import React from 'react';
 
-interface IItemProps {
+interface ItemProps {
   name: string;
   link: string;
 }
 
-const Item: React.FC<IItemProps> = ({ name, link }) => (
+const Item: React.FC<ItemProps> = ({ name, link }) => (
   <li className="PrefooterMenu__column-item">
     <a href={link}>{name}</a>
   </li>
 );
 
-interface IColumnProps {
+interface ColumnProps {
   name: string;
   link: string;
-  children: any;
 }
 
-const Column: React.FC<IColumnProps> = ({ name, link, children }) => (
+const Column: React.FC<ColumnProps> = ({ name, link, children }) => (
   <ul className="PrefooterMenu__column">
     <li className="PrefooterMenu__column-header">
       <a href={link}>{name}</a>

--- a/packages/website/src/components/RelatedContent/index.tsx
+++ b/packages/website/src/components/RelatedContent/index.tsx
@@ -6,14 +6,16 @@ interface RelatedContentProps {
   relatedContent: StreamFieldData;
 }
 
-export const RelatedContent = ({ relatedContent }: RelatedContentProps) => (
+export const RelatedContent: React.FC<RelatedContentProps> = ({
+  relatedContent,
+}) => (
   <div>
     {relatedContent.map((linkSection: any) => (
-      <div>
+      <div key={linkSection.id}>
         <h3>{linkSection.value.name || 'Related pages'}</h3>
         <ul>
           {linkSection.value.links.map((link: any) => (
-            <li>
+            <li key={link.id}>
               {link.type === 'internal_link' && (
                 <InternalAppLink key={link.id} to={link.value.link.path}>
                   {link.value.title || link.value.link.title}

--- a/packages/website/src/components/RouterAnalytics/index.tsx
+++ b/packages/website/src/components/RouterAnalytics/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { withRouter, RouteComponentProps } from 'react-router';
 
-const track = (path: string) => {
+const track = (path: string): void => {
   if (typeof ga === 'undefined') {
     return;
   }

--- a/packages/website/src/components/ScrollToTop/index.tsx
+++ b/packages/website/src/components/ScrollToTop/index.tsx
@@ -19,7 +19,7 @@ const ScrollToTopComponent: React.FC<RouteComponentProps & {
     return () => {
       unlisten();
     };
-  }, []);
+  }, [currentKey, history]);
 
   return children;
 };

--- a/packages/website/src/components/SearchApp/index.tsx
+++ b/packages/website/src/components/SearchApp/index.tsx
@@ -177,7 +177,7 @@ export const Search: React.FC<SearchProps> = ({ location }) => {
         dispatchState({ type: 'EMPTY_QUERY' });
       }
     },
-    [query],
+    [loadQueryResults, query],
   );
 
   const { area } = getParams(location);

--- a/packages/website/src/components/SearchFilterNav/index.tsx
+++ b/packages/website/src/components/SearchFilterNav/index.tsx
@@ -10,14 +10,14 @@ interface Option {
   count: number;
 }
 
-interface IItemProps {
+interface ItemProps {
   currentValue: any;
   itemKey: any;
   option: Option;
   query: string;
 }
 
-const SearchFilterItem: React.FC<IItemProps> = (props) => {
+const SearchFilterItem: React.FC<ItemProps> = (props) => {
   const { currentValue, option, query, itemKey } = props;
 
   const count = itemKey !== 'top' ? <span> {`(${option.count})`}</span> : null;
@@ -44,13 +44,13 @@ const SearchFilterItem: React.FC<IItemProps> = (props) => {
   );
 };
 
-interface IProps {
+interface SearchFilterNavProps {
   value: any;
   options: Option[];
   query: string;
 }
 
-export const SearchFilterNav: React.FC<IProps> = ({
+export const SearchFilterNav: React.FC<SearchFilterNavProps> = ({
   value,
   options,
   query,

--- a/packages/website/src/components/SearchResult/index.tsx
+++ b/packages/website/src/components/SearchResult/index.tsx
@@ -3,11 +3,9 @@ import { Event } from '@ussu/common/src/types/events';
 import { ContentBrowserPage } from '../../pages/content/types';
 import { StudentGroup } from '@ussu/common/src/types/groups';
 
-const EventSearchResult = ({
-  item: { slug, id, title, shortDescription },
-}: {
+const EventSearchResult: React.FC<{
   item: Event;
-}) => (
+}> = ({ item: { slug, id, title, shortDescription } }) => (
   <li className="ResultsList__result">
     <a className="ResultsList__link" href={`/whats-on/${slug}-${id}`}>
       <div className="ResultsList__kicker">Event</div>
@@ -17,11 +15,9 @@ const EventSearchResult = ({
   </li>
 );
 
-const StudentGroupSearchResult = ({
-  item: { name, link, description },
-}: {
+const StudentGroupSearchResult: React.FC<{
   item: StudentGroup;
-}) => (
+}> = ({ item: { name, link, description } }) => (
   <li className="ResultsList__result">
     <a className="ResultsList__link" href={link}>
       <div className="ResultsList__kicker">Sports & Societies</div>
@@ -31,11 +27,9 @@ const StudentGroupSearchResult = ({
   </li>
 );
 
-const ContentSearchResult = ({
-  item: { path, title, searchDescription },
-}: {
+const ContentSearchResult: React.FC<{
   item: ContentBrowserPage;
-}) => (
+}> = ({ item: { path, title, searchDescription } }) => (
   <li className="ResultsList__result">
     <a className="ResultsList__link" href={path}>
       <div className="ResultsList__kicker">Page</div>
@@ -45,11 +39,9 @@ const ContentSearchResult = ({
   </li>
 );
 
-const MSLPageSearchResult = ({
-  item: { link, title, description },
-}: {
+const MSLPageSearchResult: React.FC<{
   item: any;
-}) => (
+}> = ({ item: { link, title, description } }) => (
   <li className="ResultsList__result">
     <a className="ResultsList__link" href={link}>
       <div className="ResultsList__kicker">Page</div>
@@ -59,11 +51,9 @@ const MSLPageSearchResult = ({
   </li>
 );
 
-const MSLNewsResult = ({
-  item: { link, title, searchDescription },
-}: {
+const MSLNewsResult: React.FC<{
   item: any;
-}) => (
+}> = ({ item: { link, title, searchDescription } }) => (
   <li className="ResultsList__result">
     <a className="ResultsList__link" href={link}>
       <div className="ResultsList__kicker">Article</div>
@@ -81,12 +71,12 @@ export interface SearchResultData {
   description: string;
 }
 
-interface IProps {
+interface SearchResultProps {
   type: string;
   item: SearchResultData;
 }
 
-export const SearchResult: React.FC<IProps> = (props) => {
+export const SearchResult: React.FC<SearchResultProps> = (props) => {
   const { type } = props;
 
   if (type === 'Event') {

--- a/packages/website/src/components/Slate/Box.tsx
+++ b/packages/website/src/components/Slate/Box.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IBackgroundProps, OneImageBackground } from '../OneImage';
+import { OneImageBackgroundProps, OneImageBackground } from '../OneImage';
 
 export const SlateBoxContainer: React.FC = ({ children, ...props }) => (
   <div className="BentoBox" {...props}>
@@ -35,7 +35,9 @@ export const SlateBoxContainerStyleable: React.FC = ({
   </div>
 );
 
-export const SlateBoxBackground: React.FC<IBackgroundProps> = (props) => (
+export const SlateBoxBackground: React.FC<OneImageBackgroundProps> = (
+  props,
+) => (
   <OneImageBackground
     css={{
       overflow: 'auto',

--- a/packages/website/src/components/Slate/Boxes/Empty/index.tsx
+++ b/packages/website/src/components/Slate/Boxes/Empty/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { SlateBox } from '@ussu/common/src/types/slates';
 
-interface IProps {}
-
-const component: React.FC<IProps> = () => <div>select a box</div>;
+const component: React.FC = () => <div>select a box</div>;
 
 const schema = {};
 

--- a/packages/website/src/components/Slate/Boxes/Freshers2019/index.tsx
+++ b/packages/website/src/components/Slate/Boxes/Freshers2019/index.tsx
@@ -4,14 +4,19 @@ import { SlateBoxContainerStyleable } from '../../Box';
 import { InternalAppLink } from '../../../InternalAppLink';
 import { type, Typeface, TypeSize } from '@ussu/basil/src/style/type';
 
-interface IProps {
+interface SlateBoxFreshers2019Props {
   cta: string;
   link: string;
   heading: string;
   subheading: string;
 }
 
-const component: React.FC<IProps> = ({ link, cta, heading, subheading }) => {
+const component: React.FC<SlateBoxFreshers2019Props> = ({
+  link,
+  cta,
+  heading,
+  subheading,
+}) => {
   return (
     <SlateBoxContainerStyleable
       css={{

--- a/packages/website/src/components/Slate/Boxes/ImpulseButton/index.tsx
+++ b/packages/website/src/components/Slate/Boxes/ImpulseButton/index.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { SlateBox } from '@ussu/common/src/types/slates';
 
-interface IProps {
+interface SlateBoxImpulseButtonProps {
   text: string;
   link: string;
   color: 'blue' | 'red' | 'green' | 'yellow';
 }
 
-const SlateBoxImpulseButtonComponent: React.FC<IProps> = (props) => (
+const SlateBoxImpulseButtonComponent: React.FC<SlateBoxImpulseButtonProps> = (
+  props,
+) => (
   <a
     className={`type-great-primer BentoBox BentoBox--anchor BentoBox--impulse BentoBox--color-${props.color}`}
     href={props.link}

--- a/packages/website/src/components/Slate/Boxes/SimpleBranded/index.tsx
+++ b/packages/website/src/components/Slate/Boxes/SimpleBranded/index.tsx
@@ -5,14 +5,14 @@ import { SlateBox } from '@ussu/common/src/types/slates';
 import { FalmerImage } from '@ussu/common/src/types/events';
 import { SlateBoxBackground, SlateBoxContainer } from '../../Box';
 
-interface IProps {
+interface SimpleProps {
   srt: string;
   link: string;
   foregroundImage: FalmerImage;
   backgroundImage: FalmerImage;
 }
 
-const component: React.FC<IProps> = ({
+const component: React.FC<SimpleProps> = ({
   link,
   srt,
   backgroundImage,

--- a/packages/website/src/components/Slate/Boxes/SimpleText/index.tsx
+++ b/packages/website/src/components/Slate/Boxes/SimpleText/index.tsx
@@ -6,7 +6,7 @@ import { type, Typeface, TypeSize } from '@ussu/basil/src/style/type';
 import { SlateBoxBackground, SlateBoxContainer } from '../../Box';
 import { css } from '@emotion/core';
 
-interface IProps {
+interface SimpleTextProps {
   title: string;
   description: string;
   link: string;
@@ -45,7 +45,7 @@ const headingDescription = css({
   marginTop: -2,
 });
 
-const component: React.FC<IProps> = ({
+const component: React.FC<SimpleTextProps> = ({
   link,
   title,
   description,

--- a/packages/website/src/components/Slate/Boxes/VoteNow/index.tsx
+++ b/packages/website/src/components/Slate/Boxes/VoteNow/index.tsx
@@ -17,7 +17,7 @@ export enum HighlightTheme {
   WhiteOnBlack = 'w_b',
 }
 
-interface IProps {
+interface VoteNowProps {
   link: string;
   imageUrl: string;
   votingStartsDate: string;
@@ -26,13 +26,13 @@ interface IProps {
   liveCounting?: boolean;
 }
 
-interface IState {
+interface VoteNowState {
   now: Date;
 }
 
 const timeBox = { width: '100%', flex: '1 1 auto' };
 
-export class VoteNowBox extends React.Component<IProps, IState> {
+export class VoteNowBox extends React.Component<VoteNowProps, VoteNowState> {
   interval: number | undefined;
 
   state = {

--- a/packages/website/src/components/Slate/Boxes/VoteNow/index.tsx
+++ b/packages/website/src/components/Slate/Boxes/VoteNow/index.tsx
@@ -173,7 +173,7 @@ export class VoteNowBox extends React.Component<VoteNowProps, VoteNowState> {
 }
 
 export const SlateBoxVoteNow: SlateBox = {
-  component: VoteNowBox,
+  component: VoteNowBox as any,
   schema: {
     type: 'object',
     properties: {

--- a/packages/website/src/components/Slate/Boxes/boxes.ts
+++ b/packages/website/src/components/Slate/Boxes/boxes.ts
@@ -18,6 +18,6 @@ export const slateBoxes = {
 
 const boxMap = mapValues(slateBoxes, (box) => box.component);
 
-export function getAreaBox(boxType: BoxType) {
+export function getAreaBox(boxType: BoxType): React.FC {
   return boxMap.hasOwnProperty(boxType) ? boxMap[boxType] : boxMap[BoxType.NA];
 }

--- a/packages/website/src/components/SocialArray/index.tsx
+++ b/packages/website/src/components/SocialArray/index.tsx
@@ -6,7 +6,7 @@ interface NetworkInfo {
   name?: string;
 }
 
-interface IProps {
+interface SocialArrayProps {
   networks: {
     facebook?: NetworkInfo;
     twitter?: NetworkInfo;
@@ -17,7 +17,7 @@ interface IProps {
   };
 }
 
-export const SocialArray: React.FC<IProps> = ({ networks }) => (
+export const SocialArray: React.FC<SocialArrayProps> = ({ networks }) => (
   <ul className={cx('Social')}>
     {networks.facebook ? (
       <li>

--- a/packages/website/src/components/SocialMenu/index.tsx
+++ b/packages/website/src/components/SocialMenu/index.tsx
@@ -64,7 +64,7 @@ export const SocialMenu: React.FC<{ asList?: boolean; mobile?: boolean }> = ({
           <span className="u-h">Linkedin</span>
         </span>
 
-        <span className="Social__handle">Sussex Students'​ Union</span>
+        <span className="Social__handle">{`Sussex Students'​ Union`}</span>
       </a>
     </li>
     <li>

--- a/packages/website/src/components/Storybase/index.tsx
+++ b/packages/website/src/components/Storybase/index.tsx
@@ -6,7 +6,7 @@ import { store } from '../../redux/store';
 import { ApolloProvider } from '@apollo/react-hooks';
 import { StoreContext } from 'redux-react-hook';
 
-export const Storybase = (url: string = '/') => (story: () => any) => (
+export const Storybase = (url = '/') => (story: () => any) => (
   <MemoryRouter initialEntries={[url]}>
     <ApolloProvider client={getApolloClientForFalmer}>
       <StoreContext.Provider value={store}>

--- a/packages/website/src/components/StudentGroupsDiscovery/index.tsx
+++ b/packages/website/src/components/StudentGroupsDiscovery/index.tsx
@@ -220,7 +220,7 @@ export const StudentGroupListings: React.FC = () => {
             </div>
           ) : null}
           <div>
-            <h2>Can't find what you're looking for?</h2>
+            <h2>{`Can't find what you're looking for?`}</h2>
             <a
               className="Button"
               href="/sport-societies-media/start-a-new-group/"

--- a/packages/website/src/components/Tags/index.tsx
+++ b/packages/website/src/components/Tags/index.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 
-interface TagsProps {}
-
-export const Tags: React.FC<TagsProps> = ({ children }) => {
+export const Tags: React.FC = ({ children }) => {
   return <ul className="List List--reset Tags">{children}</ul>;
 };
 
-interface TagProps {}
-
-export const Tag: React.FC<TagProps> = ({ children }) => {
+export const Tag: React.FC = ({ children }) => {
   return <li className="Tags__tag">{children}</li>;
 };

--- a/packages/website/src/components/TrophyCabinet/utils.ts
+++ b/packages/website/src/components/TrophyCabinet/utils.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { AwardAuthority, GroupAward } from '@ussu/common/src/types/awards';
 import { gradeMap, iconMap } from './data';
 
-export function getGrade(award: GroupAward, authority: AwardAuthority) {
+export function getGrade(award: GroupAward, authority: AwardAuthority): Grade {
   const authoritySlug = authority.slug;
   if (gradeMap.hasOwnProperty(authoritySlug)) {
     const authorityGrades = gradeMap[authoritySlug];

--- a/packages/website/src/components/TrophyCabinet/utils.ts
+++ b/packages/website/src/components/TrophyCabinet/utils.ts
@@ -1,5 +1,9 @@
 import React from 'react';
-import { AwardAuthority, GroupAward } from '@ussu/common/src/types/awards';
+import {
+  AwardAuthority,
+  GroupAward,
+  Grade,
+} from '@ussu/common/src/types/awards';
 import { gradeMap, iconMap } from './data';
 
 export function getGrade(award: GroupAward, authority: AwardAuthority): Grade {

--- a/packages/website/src/components/VisibleChildWatcher/index.tsx
+++ b/packages/website/src/components/VisibleChildWatcher/index.tsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import { throttle, orderBy } from 'lodash';
 
-interface IChildWrapperProps {
+interface ChildWrapperProps {
   handleRef(el: HTMLDivElement): void;
 }
 
-class ChildWrapper extends React.Component<IChildWrapperProps> {
+class ChildWrapper extends React.Component<ChildWrapperProps> {
   render() {
     const { handleRef } = this.props;
     return <div ref={handleRef}>{this.props.children}</div>;
   }
 }
 
-interface IProps {
+interface VisibleChildWatcherProps {
   onChange(key: string): void;
 }
 
-export class VisibleChildWatcher extends React.Component<IProps> {
+export class VisibleChildWatcher extends React.Component<
+  VisibleChildWatcherProps
+> {
   private childEls: { [key: string]: HTMLElement } = {};
 
   componentDidMount() {

--- a/packages/website/src/components/Wayfinder/ContentWayfinder.tsx
+++ b/packages/website/src/components/Wayfinder/ContentWayfinder.tsx
@@ -21,7 +21,7 @@ export interface WayfinderProps {
 
 const contentTypeBlacklist = ['KBRootPage', 'FreshersHomepage'];
 
-const inBlacklist = (page: WayfinderPage) =>
+const inBlacklist = (page: WayfinderPage): boolean =>
   contentTypeBlacklist.indexOf(page.contentType) > -1;
 const isUsable = (page: WayfinderPage) =>
   (page !== undefined && !inBlacklist(page) && page) || null;

--- a/packages/website/src/defs/index.d.ts
+++ b/packages/website/src/defs/index.d.ts
@@ -2,6 +2,5 @@ export * from './graphql';
 export * from './htmr';
 export * from './json';
 export * from './react-countup';
-export * from './react-portal';
 export * from './react-stepper-primitive';
 export * from './svg';

--- a/packages/website/src/defs/react-portal.d.ts
+++ b/packages/website/src/defs/react-portal.d.ts
@@ -1,7 +1,0 @@
-declare module 'react-portal' {
-  class Portal extends React.Component<{
-    children: any;
-  }> {}
-
-  export { Portal };
-}

--- a/packages/website/src/defs/window.d.ts
+++ b/packages/website/src/defs/window.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  interface Window {
+    mslUserInfo: MSLUserInfo;
+  }
+}

--- a/packages/website/src/ducks/flags.ts
+++ b/packages/website/src/ducks/flags.ts
@@ -1,5 +1,3 @@
-import { AnyAction } from 'redux';
-
 interface Flag {
   name: string;
   state: boolean;
@@ -13,7 +11,6 @@ export interface FlagsState {
 
 export default function reducer(
   state: FlagsState = { loaded: false, flags: {} },
-  _action: AnyAction,
 ) {
   return state;
 }

--- a/packages/website/src/head.tsx
+++ b/packages/website/src/head.tsx
@@ -12,7 +12,7 @@ export const branding = `<link rel="apple-touch-icon" sizes="180x180" href="http
 <meta name="application-name" content="Students' Union">
 <meta name="theme-color" content="#ffffff">`;
 
-export const Branding = () => (
+export const Branding: React.FC = () => (
   <React.Fragment>
     <link
       rel="apple-touch-icon"

--- a/packages/website/src/modules/cookie_message.tsx
+++ b/packages/website/src/modules/cookie_message.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { CookieMessage } from '../components/CookieMessage';
 
-export default function onReady() {
+export default function onReady(): void {
   const el = document.createElement('div');
   document.body.insertBefore(el, document.body.firstChild);
   ReactDOM.render(<CookieMessage />, el);

--- a/packages/website/src/pages/Html.tsx
+++ b/packages/website/src/pages/Html.tsx
@@ -3,12 +3,15 @@ import { headContent } from '../head';
 import { CompProvider } from '../components/CompProviders';
 
 interface HTMLProps {
-  assets: any; // todo
-  children: any;
+  assets: any;
   additionalHead: string[];
 }
 
-export const Html = ({ children, assets, additionalHead = [] }: HTMLProps) => (
+export const Html: React.FC<HTMLProps> = ({
+  children,
+  assets,
+  additionalHead = [],
+}) => (
   <CompProvider>
     <html lang="en">
       <head

--- a/packages/website/src/pages/bookmarket/BookDetail/index.tsx
+++ b/packages/website/src/pages/bookmarket/BookDetail/index.tsx
@@ -17,8 +17,7 @@ import { RouteComponentProps } from 'react-router';
 import { useMutation, useQuery } from '@apollo/react-hooks';
 import { Loader } from '../../../components/Loader';
 
-export interface BookDetailProps
-  extends RouteComponentProps<{ listingId: string }> {}
+export type BookDetailProps = RouteComponentProps<{ listingId: string }>;
 
 interface Result {
   marketListing: MarketListing;

--- a/packages/website/src/pages/bookmarket/ListingList/index.tsx
+++ b/packages/website/src/pages/bookmarket/ListingList/index.tsx
@@ -21,7 +21,7 @@ const stateLangMap = {
   [MarketListingState.Unlisted]: 'Unlisted',
 };
 
-const ListingList: React.FC<ListingListProps> = (props: ListingListProps) => {
+const ListingList: React.FC<ListingListProps> = (props) => {
   if (props.items.length <= 0) {
     return <NoListItems />;
   }
@@ -29,7 +29,7 @@ const ListingList: React.FC<ListingListProps> = (props: ListingListProps) => {
   return (
     <ul className="ListingList List--reset">
       {props.items.map((item) => (
-        <li className="ListingList__item">
+        <li key={item.pk} className="ListingList__item">
           <FauxInternalAppLink href={`/book-market/listing/${item.pk}`} />
           <div className="ListingList__image">
             {item.image ? (

--- a/packages/website/src/pages/content/ContentPage.tsx
+++ b/packages/website/src/pages/content/ContentPage.tsx
@@ -26,7 +26,7 @@ interface Result {
   };
 }
 
-type IProps = OwnProps;
+type ContentPageProps = OwnProps;
 
 const ContentPageWrapper: React.FC<{
   page: Result['page'];
@@ -67,7 +67,7 @@ const ContentPageWrapper: React.FC<{
   );
 };
 
-const ContentPage: React.FC<IProps> = (props: IProps) => {
+const ContentPage: React.FC<ContentPageProps> = (props) => {
   const { data, loading } = useQuery<Result>(CONTENT_PAGE_QUERY, {
     variables: {
       path: props.path,

--- a/packages/website/src/pages/content/FourOhFourPage.tsx
+++ b/packages/website/src/pages/content/FourOhFourPage.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
-export const FourOhFourPage = () => (
+export const FourOhFourPage: React.FC = () => (
   <div className="Stonewall Stonewall--small">
     <Helmet title="404" />
     <h1>404 - Page not found</h1>
-    <p>Sorry we couldn't find the page you were looking for.</p>
+    <p>{`Sorry we couldn't find the page you were looking for.`}</p>
     <p>
-      We're always looking to improve our website. If you think there should be
+      {`We're always looking to improve our website. If you think there should be
       a page here, or you can't find what you're looking for, please email
-      support@sussexstudent.com.
+      support@sussexstudent.com.`}
     </p>
   </div>
 );

--- a/packages/website/src/pages/content/pages/FreshersSwitcher.tsx
+++ b/packages/website/src/pages/content/pages/FreshersSwitcher.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { FreshersHomepage } from './FreshersHomepage';
+import { FreshersHomepage, FreshersHomepageProps } from './FreshersHomepage';
 
-export const FreshersSwitcher = (props: any) => {
+export const FreshersSwitcher: React.FC<FreshersHomepageProps> = (props) => {
   return <FreshersHomepage {...props} />;
 };

--- a/packages/website/src/pages/content/pages/KBCategoryPage.tsx
+++ b/packages/website/src/pages/content/pages/KBCategoryPage.tsx
@@ -4,16 +4,12 @@ import { BreadcrumbBar } from '../../../components/BreadcrumbBar';
 import { Link } from 'react-router-dom';
 import { Typeface, TypeSize, type } from '@ussu/basil/src/style/type';
 
-interface IKBRoot extends Page {}
-
-interface IKBContentPage extends Page {}
-
-interface IKBCategoryPage extends Page<IKBContentPage[]> {
-  rootPage: IKBRoot;
+interface KBCategoryPageData extends Page<Page[]> {
+  rootPage: Page;
 }
 
 export interface KBCategoryPageProps {
-  page: IKBCategoryPage;
+  page: KBCategoryPageData;
 }
 
 export const KBCategoryPage: React.FC<KBCategoryPageProps> = ({ page }) => (

--- a/packages/website/src/pages/content/pages/SectionContentPage.tsx
+++ b/packages/website/src/pages/content/pages/SectionContentPage.tsx
@@ -17,7 +17,7 @@ import { FalmerImage } from '@ussu/common/src/types/events';
 import { OneImage } from '../../../components/OneImage';
 import { Heading, HeadingLevel } from '../../../components/Heading';
 
-interface ISectionContentPage extends Page {
+interface SectionContentPageData extends Page {
   title: string;
   sidebarBody: any;
   body: any;
@@ -27,16 +27,16 @@ interface ISectionContentPage extends Page {
 }
 
 export interface SectionContentPageProps {
-  page: ISectionContentPage;
+  page: SectionContentPageData;
 }
 
-interface IState {
+interface SectionContentPageState {
   visibleKey: null | string;
 }
 
 class SectionContentPage extends React.Component<
   SectionContentPageProps,
-  IState
+  SectionContentPageState
 > {
   state = {
     visibleKey: null,

--- a/packages/website/src/pages/content/pages/StaffPage.tsx
+++ b/packages/website/src/pages/content/pages/StaffPage.tsx
@@ -35,12 +35,12 @@ const levelMap = {
   staff_list: 1,
 };
 
-interface IStaffPage extends Page {
+interface StaffPageData extends Page {
   body: any;
 }
 
 export interface StaffPageProps {
-  page: IStaffPage; // todo
+  page: StaffPageData; // todo
 }
 
 export const StaffPage: React.FC<StaffPageProps> = ({

--- a/packages/website/src/pages/content/utils.ts
+++ b/packages/website/src/pages/content/utils.ts
@@ -2,7 +2,7 @@ import { isString, castArray } from 'lodash';
 import htmr from 'htmr';
 import { StreamFieldBlockData, StreamFieldData } from './types';
 
-export function normaliseContentLink(link: string | null) {
+export function normaliseContentLink(link: string | null): string {
   if (link === null) {
     return '';
   }
@@ -18,7 +18,7 @@ export function getTextFromElementChildren(children: any | any[]): string {
     .join(' ');
 }
 
-export function getTextFromElement(element: React.ReactElement<any>) {
+export function getTextFromElement(element: React.ReactElement): string {
   if (element.props.children) {
     return getTextFromElementChildren(element.props.children);
   }

--- a/packages/website/src/pages/freshers/FreshersContainer.tsx
+++ b/packages/website/src/pages/freshers/FreshersContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export const FreshersContainer = (props: any) => (
+export const FreshersContainer: React.FC = (props) => (
   <div className="FreshersSite u-keep-footer-down">{props.children}</div>
 );

--- a/packages/website/src/pages/freshers/FreshersEvents.tsx
+++ b/packages/website/src/pages/freshers/FreshersEvents.tsx
@@ -57,7 +57,7 @@ export const FreshersEvents: React.FC<FreshersEventsProps> = ({ location }) => {
   return (
     <FreshersContainer>
       <div className="LokiContainer">
-        <h1>What's on</h1>
+        <h1>{`What's on`}</h1>
         <div>
           Filter to:
           <SimpleFilterList>

--- a/packages/website/src/pages/whatson/EventDetailPage/EventDetailDetails.tsx
+++ b/packages/website/src/pages/whatson/EventDetailPage/EventDetailDetails.tsx
@@ -25,7 +25,7 @@ function isSameLogicalSleepDay(startDate: Date, endDate: Date): boolean {
   return isSameDay(addDays(startDate, 1), endDate) && getHours(endDate) < 7;
 }
 
-interface IProps {
+interface EventDetailDetailsProps {
   event: Event;
 }
 
@@ -73,7 +73,9 @@ function renderDates(event: Event) {
   );
 }
 
-export const EventDetailDetails = (props: IProps) => {
+export const EventDetailDetails: React.FC<EventDetailDetailsProps> = (
+  props,
+) => {
   const { event } = props;
 
   return (

--- a/packages/website/src/pages/whatson/EventDetailPage/EventDetailSidebar.tsx
+++ b/packages/website/src/pages/whatson/EventDetailPage/EventDetailSidebar.tsx
@@ -7,7 +7,7 @@ import { formatPrice } from '@ussu/common/src/libs/money';
 import { every } from 'lodash';
 import { EventSidebarSection } from './EventSidebarSection';
 
-interface IProps {
+interface EventDetailSidebarProps {
   event: Event;
   msl: any;
   onTicketButton(): void;
@@ -30,8 +30,8 @@ function mslSubtitle(msl: any) {
 
   const costs = msl.tickets.map((ticket: any) => ticket.value);
 
-  const min = Math.min.apply(Math, costs);
-  const max = Math.min.apply(Math, costs);
+  const min = Math.min(...costs);
+  const max = Math.min(...costs);
 
   if (min <= 0 && max <= 0) {
     return 'Free!';
@@ -40,7 +40,9 @@ function mslSubtitle(msl: any) {
   return min === max ? `£${formatPrice(min)}` : `from £${formatPrice(min)}`;
 }
 
-export const EventDetailSidebar = (props: IProps) => {
+export const EventDetailSidebar: React.FC<EventDetailSidebarProps> = (
+  props,
+) => {
   const { event, msl } = props;
 
   const ticketCta =

--- a/packages/website/src/pages/whatson/EventDetailPage/MSLEventCommunication.tsx
+++ b/packages/website/src/pages/whatson/EventDetailPage/MSLEventCommunication.tsx
@@ -2,26 +2,29 @@ import React, { useCallback, useEffect } from 'react';
 import { replacePageActions } from '../../../ducks/page';
 import { useDispatch } from 'redux-react-hook';
 
-interface IProps {
+interface MSLEventCommunication {
   ticketData: string;
   onData(data: any): void;
 }
 
-export const MSLEventCommunication: React.FC<IProps> = ({
+export const MSLEventCommunication: React.FC<MSLEventCommunication> = ({
   ticketData,
   onData,
 }) => {
   const dispatch = useDispatch();
-  const handleMessage = useCallback((e: MessageEvent) => {
-    const data = e.data;
-    if (data.source === 'ussu-msl-frame-initial-data') {
-      onData(data.payload);
+  const handleMessage = useCallback(
+    (e: MessageEvent) => {
+      const data = e.data;
+      if (data.source === 'ussu-msl-frame-initial-data') {
+        onData(data.payload);
 
-      if (data.payload.pageMenuOptions) {
-        dispatch(replacePageActions(data.payload.pageMenuOptions));
+        if (data.payload.pageMenuOptions) {
+          dispatch(replacePageActions(data.payload.pageMenuOptions));
+        }
       }
-    }
-  }, []);
+    },
+    [dispatch, onData],
+  );
 
   useEffect(() => {
     window.addEventListener('message', handleMessage);
@@ -29,7 +32,7 @@ export const MSLEventCommunication: React.FC<IProps> = ({
     return () => {
       window.removeEventListener('message', handleMessage);
     };
-  }, []);
+  }, [handleMessage]);
 
   return (
     <iframe

--- a/packages/website/src/pages/whatson/EventDetailPage/MSLTickets.tsx
+++ b/packages/website/src/pages/whatson/EventDetailPage/MSLTickets.tsx
@@ -4,18 +4,21 @@ import { Button } from '../../../components/Button';
 import Stepper from 'react-stepper-primitive';
 import { formatPrice } from '@ussu/common/src/libs/money';
 
-interface IProps {
+interface MSLTicketsProps {
   msl: any;
 }
 
-interface IState {
+interface MSLTicketsState {
   ticketSelection: {
     [id: string]: number;
   };
 }
 
-export class MSLTickets extends React.Component<IProps, IState> {
-  constructor(props: IProps) {
+export class MSLTickets extends React.Component<
+  MSLTicketsProps,
+  MSLTicketsState
+> {
+  constructor(props: MSLTicketsProps) {
     super(props);
 
     this.state = {

--- a/packages/website/src/pages/whatson/EventDetailPage/TicketsModal.tsx
+++ b/packages/website/src/pages/whatson/EventDetailPage/TicketsModal.tsx
@@ -16,7 +16,7 @@ export const TicketsModal: React.FC<TicketsModalProps & ReactModal.Props> = (
     <ul>
       {props.msl &&
         props.msl.tickets.map((ticket) => (
-          <li>
+          <li key={ticket.ticketName}>
             {ticket.ticketName}{' '}
             {ticket.value <= 0
               ? 'Free'

--- a/packages/website/src/pages/whatson/EventDetailPage/index.tsx
+++ b/packages/website/src/pages/whatson/EventDetailPage/index.tsx
@@ -57,7 +57,7 @@ export const EventDetailPage: React.FC<EventDetailPageProps> = ({
         dispatch(setBrandingPeriod(event.brand.slug));
       }
     }
-  }, [data]);
+  }, [data, dispatch, history, match.params]);
 
   if (!data || loading) {
     return <Loader />;

--- a/packages/website/src/pages/whatson/WhatsOnEventCard/tags.ts
+++ b/packages/website/src/pages/whatson/WhatsOnEventCard/tags.ts
@@ -16,7 +16,7 @@ function createTag(title: string, type: EventTagType): EventTag {
   return { title, type, id: `${type}/${title}` };
 }
 
-export function* getTagsForEvent(event: Event): Iterator<EventTag> {
+export function* getTagsForEvent(event: Event) {
   if (event.isOver18Only) {
     yield createTag('18+', EventTagType.Requirement);
   }

--- a/packages/website/src/pages/whatson/WhatsOnEventCard/tags.ts
+++ b/packages/website/src/pages/whatson/WhatsOnEventCard/tags.ts
@@ -16,7 +16,7 @@ function createTag(title: string, type: EventTagType): EventTag {
   return { title, type, id: `${type}/${title}` };
 }
 
-export function* getTagsForEvent(event: Event) {
+export function* getTagsForEvent(event: Event): Iterator<EventTag> {
   if (event.isOver18Only) {
     yield createTag('18+', EventTagType.Requirement);
   }

--- a/packages/website/src/pages/whatson/WhatsOnEventCard/utils.tsx
+++ b/packages/website/src/pages/whatson/WhatsOnEventCard/utils.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Event } from '@ussu/common/src/types/events';
 
-export function renderEventLocation(event: Event) {
+export function renderEventLocation(event: Event): null | React.ReactElement {
   if (!event.venue) {
     if (event.locationDisplay === '') {
       return null;

--- a/packages/website/src/pages/whatson/WhatsOnListings/EventBrandingPeriod.tsx
+++ b/packages/website/src/pages/whatson/WhatsOnListings/EventBrandingPeriod.tsx
@@ -77,7 +77,7 @@ export const EventBrandingPeriod: React.FC<EventBrandingPeriodProps> = ({
 
   useEffect(() => {
     dispatch(setBrandingPeriod(brandSlug));
-  }, [brandSlug]);
+  }, [brandSlug, dispatch]);
 
   if (brandLoading || listingsLoading) {
     return <Loader dark />;

--- a/packages/website/src/pages/whatson/WhatsOnListings/EventLikeButton.tsx
+++ b/packages/website/src/pages/whatson/WhatsOnListings/EventLikeButton.tsx
@@ -28,7 +28,7 @@ export const EventLikeButton: React.FC<{ event: Event }> = ({ event }) => {
       console.log(isAuthenticated, openLoginModal());
       dispatch(openLoginModal());
     }
-  }, [loading, isAuthenticated, likeEvent, event.userLike]);
+  }, [isAuthenticated, likeEvent, event.eventId, event.userLike, dispatch]);
 
   const isLiked = event.userLike && event.userLike.source === 'USER';
 

--- a/packages/website/src/pages/whatson/WhatsOnListings/index.tsx
+++ b/packages/website/src/pages/whatson/WhatsOnListings/index.tsx
@@ -22,7 +22,7 @@ const EventsList: React.FC<EventsListProps> = ({ filter }) => {
   const dispatch = useWhatsOnThemingContext()[1];
   useEffect(() => {
     dispatch(setBrandingPeriod(null));
-  }, []);
+  }, [dispatch]);
   const [now] = useState(new Date());
   const { data, loading } = useQuery(EventListingsQuery, {
     variables: {

--- a/packages/website/src/pages/whatson/WhatsOnMyProgramme/index.tsx
+++ b/packages/website/src/pages/whatson/WhatsOnMyProgramme/index.tsx
@@ -5,9 +5,7 @@ import { startOfDay, addMonths } from 'date-fns';
 import { Loader } from '../../../components/Loader';
 import { EventListings } from '../WhatsOnListings/EventListings';
 
-export interface WhatsOnMyProgrammeProps {}
-
-export const WhatsOnMyProgramme: React.FC<WhatsOnMyProgrammeProps> = ({}) => {
+export const WhatsOnMyProgramme: React.FC = () => {
   const [now] = useState(new Date());
   const { data, loading } = useQuery(getUserLikedEvents, {
     variables: {

--- a/packages/website/src/pages/whatson/index.tsx
+++ b/packages/website/src/pages/whatson/index.tsx
@@ -9,7 +9,6 @@ import { EventDetailPageProps } from './EventDetailPage';
 import loadable from '@loadable/component';
 import { BrandingContainer } from './branding/components';
 import { WhatsOnThemingProvider } from './WhatsOnBrandingContext';
-import { WhatsOnMyProgrammeProps } from './WhatsOnMyProgramme';
 import {
   Wayfinder,
   WayfinderTopLevel,
@@ -43,7 +42,7 @@ const LoadableDetail = loadable<EventDetailPageProps>(async () => {
   return (props) => <EventDetailPage {...props} />;
 });
 
-const LoadableMyProgramme = loadable<WhatsOnMyProgrammeProps>(async () => {
+const LoadableMyProgramme = loadable(async () => {
   const { WhatsOnMyProgramme } = await import('./WhatsOnMyProgramme');
   return (props) => <WhatsOnMyProgramme {...props} />;
 });

--- a/packages/website/src/pages/whatson/utils.tsx
+++ b/packages/website/src/pages/whatson/utils.tsx
@@ -76,7 +76,7 @@ export function splitEventsInToParts(events: Event[], removePast = true) {
   return parts;
 }
 
-function poorMonthSort(key: string) {
+function poorMonthSort(key: string): number {
   if (key === '0') {
     return 0;
   }
@@ -142,7 +142,7 @@ export function organisePartsForUI(eventParts: EventPart[], removePast = true) {
   return asList;
 }
 
-export function getOrdinal(day: number) {
+export function getOrdinal(day: number): 'st' | 'nd' | 'th' | 'rd' {
   const rem100 = day % 100;
   if (rem100 > 20 || rem100 < 10) {
     switch (rem100 % 10) {
@@ -157,7 +157,7 @@ export function getOrdinal(day: number) {
   return 'th';
 }
 
-export function getSmartDate(part: EventPart) {
+export function getSmartDate(part: EventPart): string | React.ReactElement {
   if (isSameDay(new Date(), part.date)) {
     return 'Today';
   }
@@ -178,7 +178,7 @@ export function getSmartDate(part: EventPart) {
   );
 }
 
-export function generateStylesForBrand(brand: Brand) {
+export function generateStylesForBrand(brand: Brand): object {
   if (!brand.accent) {
     return {};
   }

--- a/packages/website/src/previewEntry.tsx
+++ b/packages/website/src/previewEntry.tsx
@@ -1,5 +1,6 @@
 import '../../common/src/css/main.css';
 
+import React from 'react';
 import Raven from 'raven-js';
 import mitt from 'mitt';
 import { addClassesForFeatures } from '@ussu/common/src/libs/features';

--- a/packages/website/src/stores/page.ts
+++ b/packages/website/src/stores/page.ts
@@ -89,4 +89,4 @@ const usePage = (): [PageState, React.Dispatch<Actions>] => {
   return [store, dispatch];
 };
 
-export let PageStore = createContainer(usePage);
+export const PageStore = createContainer(usePage);

--- a/packages/website/src/stores/router.ts
+++ b/packages/website/src/stores/router.ts
@@ -177,4 +177,4 @@ const useRouter = (): [RouterState, React.Dispatch<Actions>] => {
   return [store, dispatch];
 };
 
-export let RouterStore = createContainer(useRouter);
+export const RouterStore = createContainer(useRouter);

--- a/packages/website/src/stores/user.ts
+++ b/packages/website/src/stores/user.ts
@@ -97,4 +97,4 @@ const useUser = (): [UserState, React.Dispatch<Actions>] => {
   return [store, dispatch];
 };
 
-export let UserStore = createContainer(useUser);
+export const UserStore = createContainer(useUser);

--- a/packages/website/src/visualBootstrap.ts
+++ b/packages/website/src/visualBootstrap.ts
@@ -3,7 +3,7 @@ import currentUser from '@ussu/common/src/libs/user';
 import Modal from 'react-modal';
 import hydro from './modules/hydro';
 
-export function setup() {
+export function setup(): void {
   if (document.querySelector('.Body')) {
     Modal.setAppElement('.Body');
   } else if (document.querySelector('#root')) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,12 @@
     "experimentalDecorators": true,
     "allowJs": true,
     "baseUrl": "."
-  }
+  },
+  "include": [
+    "packages/website/src/**/*",
+    "packages/falmer/src/**/*",
+    "packages/basil/src/**/*",
+    "packages/common/src/**/*",
+  ]
 }
 


### PR DESCRIPTION
We should be following eslint, but currently we have a fair few warnings - mostly ts rules disallowing `any` which was used a fair bit in the initial port to TypeScript.

This PR is about getting our warning count down. Once down, we will add running eslint to our CI and Danger.