### PR TITLE
Fix first line indent of NewsBlock title

### DIFF
--- a/packages/website/src/components/NewsList/NewsBlock.tsx
+++ b/packages/website/src/components/NewsList/NewsBlock.tsx
@@ -95,7 +95,6 @@ export const NewsBlock: React.FC<IProps> = ({
           css={{
             textDecoration: 'none',
             paddingRight: '1rem',
-            padding: '0.02em 0.2em',
             color: '#000',
             display: 'inline',
             position: 'relative',

--- a/packages/website/src/components/NewsList/NewsBlock.tsx
+++ b/packages/website/src/components/NewsList/NewsBlock.tsx
@@ -95,21 +95,16 @@ export const NewsBlock: React.FC<IProps> = ({
           css={{
             textDecoration: 'none',
             paddingRight: '1rem',
+            padding: '0.02em 0.2em',
+            color: '#000',
+            display: 'inline',
+            position: 'relative',
+            margin: 0,
+            fontWeight: 600,
+            ...type(TypeSize.GreatPrimer, Typeface.Secondary),
           }}
         >
-          <span
-            css={{
-              padding: '0.02em 0.2em',
-              color: '#000',
-              display: 'inline',
-              position: 'relative',
-              margin: 0,
-              fontWeight: 600,
-              ...type(TypeSize.GreatPrimer, Typeface.Secondary),
-            }}
-          >
-            {title}
-          </span>
+          {title}
         </div>
         <p
           css={{


### PR DESCRIPTION
Before
<img width="312" alt="Screenshot 2019-12-04 at 12 19 35" src="https://user-images.githubusercontent.com/382352/70142080-60999100-1690-11ea-836f-f4480bdb4de6.png">


After
<img width="316" alt="Screenshot 2019-12-04 at 12 20 41" src="https://user-images.githubusercontent.com/382352/70142177-8d4da880-1690-11ea-856f-bd870e183549.png">

